### PR TITLE
ci: pre-commit script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+solhint "**/*.sol" -w 0
+slither ./
+forge clean && forge test
+
+if ! bash jobs/check_coverage.sh; then
+  echo "run this command to check coverage details with lcov: forge clean > /dev/null && forge build > /dev/null && forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage --ignore-errors category,category,inconsistent"
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Space and Time | ZKPay Smart Contracts
+
+## Git Hooks
+
+This repository includes a sample pre-commit hook located in `githooks/pre-commit`.
+It runs linting with `solhint`, static analysis with `slither`, tests, and
+verifies that coverage is 100%.
+
+To enable it locally, symlink it into your Git hooks directory:
+
+```bash
+ln -s ../../githooks/pre-commit .git/hooks/pre-commit
+````
+
+or configure the hook location:
+
+```
+git config core.hooksPath .githooks      
+```
+


### PR DESCRIPTION

# Rationale for this change
There are many tools that being forced in CI and running these tools locally is essential so I'm adding this pre-commit script to validate all lints, tests and CI passes before commit - keep in mind you can skip that with --no-verify flag

# What changes are included in this PR?
- README.md docs
- added pre-commit script 
# Are these changes tested?
No need