### PR TITLE
feat: validate paywall prices on payment (to be split) 

### DIFF
--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -252,29 +252,6 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
     }
 
     /// @inheritdoc IZKPay
-    function sendNative(bytes32 onBehalfOf, address target, bytes calldata memo) external payable nonReentrant {
-        if (msg.value > type(uint248).max) {
-            revert ValueExceedsUint248Limit();
-        }
-
-        uint248 amount = uint248(msg.value);
-
-        (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) =
-            _assets.send(NATIVE_ADDRESS, amount, target, _treasury, _sxt);
-        emit SendPayment(
-            NATIVE_ADDRESS,
-            actualAmountReceived,
-            protocolFeeAmount,
-            onBehalfOf,
-            target,
-            memo,
-            amountInUSD,
-            msg.sender,
-            bytes32(0)
-        );
-    }
-
-    /// @inheritdoc IZKPay
     function setMerchantConfig(MerchantLogic.MerchantConfig calldata config, bytes calldata path) external {
         _merchantConfigs.set(msg.sender, config);
         _swapLogicStorage.setMerchantTargetAssetPath(msg.sender, path);

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -236,7 +236,7 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         address asset,
         uint248 amount,
         bytes32 onBehalfOf,
-        address target,
+        address merchant,
         bytes calldata memo,
         bytes32 itemId
     ) external nonReentrant {
@@ -245,9 +245,10 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         }
 
         (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) =
-            _assets.send(asset, amount, target, _treasury, _sxt);
+            _assets.send(asset, amount, merchant, _treasury, _sxt);
+
         emit SendPayment(
-            asset, actualAmountReceived, protocolFeeAmount, onBehalfOf, target, memo, amountInUSD, msg.sender, itemId
+            asset, actualAmountReceived, protocolFeeAmount, onBehalfOf, merchant, memo, amountInUSD, msg.sender, itemId
         );
     }
 

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -232,10 +232,14 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
     }
 
     /// @inheritdoc IZKPay
-    function send(address asset, uint248 amount, bytes32 onBehalfOf, address target, bytes calldata memo)
-        external
-        nonReentrant
-    {
+    function send(
+        address asset,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address target,
+        bytes calldata memo,
+        bytes32 itemId
+    ) external nonReentrant {
         if (asset == NATIVE_ADDRESS) {
             revert NotErc20Token();
         }
@@ -243,7 +247,7 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) =
             _assets.send(asset, amount, target, _treasury, _sxt);
         emit SendPayment(
-            asset, actualAmountReceived, protocolFeeAmount, onBehalfOf, target, memo, amountInUSD, msg.sender
+            asset, actualAmountReceived, protocolFeeAmount, onBehalfOf, target, memo, amountInUSD, msg.sender, itemId
         );
     }
 
@@ -258,7 +262,15 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) =
             _assets.send(NATIVE_ADDRESS, amount, target, _treasury, _sxt);
         emit SendPayment(
-            NATIVE_ADDRESS, actualAmountReceived, protocolFeeAmount, onBehalfOf, target, memo, amountInUSD, msg.sender
+            NATIVE_ADDRESS,
+            actualAmountReceived,
+            protocolFeeAmount,
+            onBehalfOf,
+            target,
+            memo,
+            amountInUSD,
+            msg.sender,
+            bytes32(0)
         );
     }
 

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -145,12 +145,6 @@ interface IZKPay {
         bytes32 itemId
     ) external;
 
-    /// @notice Allows for sending native tokens to a target address
-    /// @param onBehalfOf The identifier on whose behalf the payment is made
-    /// @param target The target address to receive the payment
-    /// @param memo Additional data or information about the payment
-    function sendNative(bytes32 onBehalfOf, address target, bytes calldata memo) external payable;
-
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct
     /// @param path The path for the target asset to swap to USDT (USDT => targetAsset)

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -53,7 +53,7 @@ interface IZKPay {
     /// @param amount The amount of tokens used for payment
     /// @param protocolFeeAmount The amount of protocol fee in source token.
     /// @param onBehalfOf The identifier on whose behalf the payment was made
-    /// @param target The target address
+    /// @param merchant The merchant address
     /// @param memo Additional data or information about the payment
     /// @param amountInUSD The amount in USD
     /// @param sender The address that initiated the payment
@@ -63,7 +63,7 @@ interface IZKPay {
         uint248 amount,
         uint248 protocolFeeAmount,
         bytes32 onBehalfOf,
-        address indexed target,
+        address indexed merchant,
         bytes memo,
         uint248 amountInUSD,
         address indexed sender,

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -57,6 +57,7 @@ interface IZKPay {
     /// @param memo Additional data or information about the payment
     /// @param amountInUSD The amount in USD
     /// @param sender The address that initiated the payment
+    /// @param itemId Item identifier for the payment
     event SendPayment(
         address indexed asset,
         uint248 amount,
@@ -65,7 +66,8 @@ interface IZKPay {
         address indexed target,
         bytes memo,
         uint248 amountInUSD,
-        address indexed sender
+        address indexed sender,
+        bytes32 itemId
     );
 
     /// @notice Sets the treasury address
@@ -133,7 +135,15 @@ interface IZKPay {
     /// @param onBehalfOf The identifier on whose behalf the payment is made
     /// @param target The target address to receive the payment
     /// @param memo Additional data or information about the payment
-    function send(address asset, uint248 amount, bytes32 onBehalfOf, address target, bytes calldata memo) external;
+    /// @param itemId Item identifier for the payment
+    function send(
+        address asset,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address target,
+        bytes calldata memo,
+        bytes32 itemId
+    ) external;
 
     /// @notice Allows for sending native tokens to a target address
     /// @param onBehalfOf The identifier on whose behalf the payment is made

--- a/test/FixedPriceFeed.t.sol
+++ b/test/FixedPriceFeed.t.sol
@@ -185,6 +185,7 @@ contract FixedPriceFeedTest is Test {
         MockERC20(asset).approve(address(zkpay), amount);
 
         // query
+        MockCustomLogic mockedCustomLogic = new MockCustomLogic();
         QueryLogic.QueryRequest memory queryRequest = QueryLogic.QueryRequest({
             query: "test",
             queryParameters: "test",
@@ -192,7 +193,7 @@ contract FixedPriceFeedTest is Test {
             callbackClientContractAddress: clientContractAddress,
             callbackGasLimit: 1000000,
             callbackData: "test",
-            customLogicContractAddress: address(this)
+            customLogicContractAddress: address(mockedCustomLogic)
         });
 
         // query

--- a/test/FixedPriceFeed.t.sol
+++ b/test/FixedPriceFeed.t.sol
@@ -141,7 +141,7 @@ contract FixedPriceFeedTest is Test {
 
         // send
         vm.prank(payer);
-        zkpay.send(asset, amount, onBehalfOf, target, memo);
+        zkpay.send(asset, amount, onBehalfOf, target, memo, bytes32(0));
     }
 
     function testQueryWithFixedPriceFeed() public {

--- a/test/PaymentFunctions.t.sol
+++ b/test/PaymentFunctions.t.sol
@@ -101,6 +101,18 @@ contract PaymentFunctionsTest is Test {
         assertEq(usdc.balanceOf(treasury), protocolFeeAmount);
     }
 
+    function testSendInsufficientPayment() public {
+        bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
+
+        usdc.approve(address(zkpay), usdcAmount);
+
+        vm.prank(targetMerchant);
+        zkpay.setPaywallItemPrice(bytes32(uint256(itemId)), usdcAmount * 1e12 + 1);
+
+        vm.expectRevert(ZKPay.InsufficientPayment.selector);
+        zkpay.send(address(usdc), usdcAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(uint256(itemId)));
+    }
+
     function testSendWithoutProtocolFee() public {
         address sxtToken = zkpay.getSXT();
         MockERC20 sxt = MockERC20(sxtToken);

--- a/test/PaymentFunctions.t.sol
+++ b/test/PaymentFunctions.t.sol
@@ -20,7 +20,7 @@ contract PaymentFunctionsTest is Test {
     MockERC20 public usdc;
     uint248 public usdcAmount;
     uint248 public nativeAmount;
-    address public targetProtocol;
+    address public targetMerchant;
     uint64 public itemId;
     address public onBehalfOf;
     bytes public memoBytes;
@@ -34,7 +34,7 @@ contract PaymentFunctionsTest is Test {
         owner = vm.addr(0x1);
         treasury = vm.addr(0x2);
         onBehalfOf = vm.addr(0x3);
-        targetProtocol = vm.addr(0x4);
+        targetMerchant = vm.addr(0x4);
         itemId = 123;
 
         // Convert itemId to bytes for the new parameter type
@@ -93,11 +93,11 @@ contract PaymentFunctionsTest is Test {
         bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
 
         usdc.approve(address(zkpay), usdcAmount);
-        zkpay.send(address(usdc), usdcAmount, onBehalfOfBytes32, targetProtocol, memoBytes, bytes32(0));
+        zkpay.send(address(usdc), usdcAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(0));
 
         uint248 protocolFeeAmount = uint248((uint256(usdcAmount) * PROTOCOL_FEE) / PROTOCOL_FEE_PRECISION);
 
-        assertEq(usdc.balanceOf(targetProtocol), usdcAmount - protocolFeeAmount);
+        assertEq(usdc.balanceOf(targetMerchant), usdcAmount - protocolFeeAmount);
         assertEq(usdc.balanceOf(treasury), protocolFeeAmount);
     }
 
@@ -124,9 +124,9 @@ contract PaymentFunctionsTest is Test {
         vm.stopPrank();
 
         sxt.approve(address(zkpay), sxtAmount);
-        zkpay.send(sxtToken, sxtAmount, onBehalfOfBytes32, targetProtocol, memoBytes, bytes32(0));
+        zkpay.send(sxtToken, sxtAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(0));
 
-        assertEq(sxt.balanceOf(targetProtocol), sxtAmount);
+        assertEq(sxt.balanceOf(targetMerchant), sxtAmount);
         assertEq(sxt.balanceOf(treasury), 0);
     }
 
@@ -134,17 +134,17 @@ contract PaymentFunctionsTest is Test {
         bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
 
         vm.expectRevert(ZKPay.NotErc20Token.selector);
-        zkpay.send(NATIVE_ADDRESS, nativeAmount, onBehalfOfBytes32, targetProtocol, memoBytes, bytes32(0));
+        zkpay.send(NATIVE_ADDRESS, nativeAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(0));
     }
 
-    function testSendToZeroAddress() public {
+    function testSendToZeroMerchantAddress() public {
         // Convert onBehalfOf address to bytes32
         bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
 
         // Approve the ZKPay contract to spend our USDC
         usdc.approve(address(zkpay), usdcAmount);
 
-        vm.expectRevert(AssetManagement.TargetAddressCannotBeZero.selector);
+        vm.expectRevert(AssetManagement.MerchantAddressCannotBeZero.selector);
         // Call the send function
         zkpay.send(address(usdc), usdcAmount, onBehalfOfBytes32, address(0), memoBytes, bytes32(0));
     }
@@ -153,7 +153,7 @@ contract PaymentFunctionsTest is Test {
         address invalidAsset = vm.addr(0x5);
 
         vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
-        zkpay.send(invalidAsset, 100, bytes32(uint256(uint160(onBehalfOf))), targetProtocol, memoBytes, bytes32(0));
+        zkpay.send(invalidAsset, 100, bytes32(uint256(uint160(onBehalfOf))), targetMerchant, memoBytes, bytes32(0));
     }
 
     function testSendWithUnsupportedPaymentType() public {
@@ -175,7 +175,7 @@ contract PaymentFunctionsTest is Test {
         vm.stopPrank();
 
         vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
-        zkpay.send(newToken, usdcAmount, bytes32(uint256(uint160(onBehalfOf))), targetProtocol, memoBytes, bytes32(0));
+        zkpay.send(newToken, usdcAmount, bytes32(uint256(uint160(onBehalfOf))), targetMerchant, memoBytes, bytes32(0));
     }
 
     receive() external payable {}

--- a/test/QueryCancelation.t.sol
+++ b/test/QueryCancelation.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {MockV3Aggregator} from "@chainlink/contracts/src/v0.8/tests/MockV3Aggregator.sol";
+import {MockCustomLogic} from "./mocks/MockCustomLogic.sol";
 
 import {ZKPay} from "../src/ZKPay.sol";
 import {AssetManagement} from "../src/libraries/AssetManagement.sol";
@@ -77,7 +78,7 @@ contract QueryCancelationTest is Test {
 
         vm.stopPrank();
 
-        address customLogicContractAddress = address(0x101);
+        MockCustomLogic mockedCustomLogic = new MockCustomLogic();
 
         // deploy custom logic contract
         _queryRequest = QueryLogic.QueryRequest({
@@ -87,7 +88,7 @@ contract QueryCancelationTest is Test {
             callbackClientContractAddress: address(this),
             callbackGasLimit: 1_000_000,
             callbackData: "test",
-            customLogicContractAddress: customLogicContractAddress
+            customLogicContractAddress: address(mockedCustomLogic)
         });
 
         // allow the zkpay contract to transfer usdc

--- a/test/ZKPay.t.sol
+++ b/test/ZKPay.t.sol
@@ -472,69 +472,6 @@ contract ZKPayTest is Test, IZKPayClient {
         zkpay.query(address(usdc), usdcAmount, queryRequest);
     }
 
-    function testPayNativeExceedsUint248Limit() public {
-        // Set up initial state
-        address onBehalfOfAddr = address(0x123);
-        bytes32 onBehalfOf = bytes32(uint256(uint160(onBehalfOfAddr)));
-        address target = address(0x456);
-        uint64 itemId = 789;
-        bytes memory memo = abi.encode(itemId);
-        uint256 excessiveAmount = uint256(type(uint248).max) + 1;
-
-        // Fund the test contract
-        vm.deal(address(this), excessiveAmount);
-
-        // Expect revert due to excessive amount
-        vm.expectRevert(ZKPay.ValueExceedsUint248Limit.selector);
-        zkpay.sendNative{value: excessiveAmount}(onBehalfOf, target, memo);
-    }
-
-    // Use the RejectEther contract defined outside this contract
-    function testPayNativeFailedTransfer() public {
-        // Set up initial state
-        address onBehalfOfAddr = address(0x123);
-        bytes32 onBehalfOf = bytes32(uint256(uint160(onBehalfOfAddr)));
-        uint64 itemId = 789;
-        bytes memory memo = abi.encode(itemId);
-        uint248 amount = 1 ether;
-
-        vm.prank(_owner);
-        zkpay.setPaymentAsset(NATIVE_ADDRESS, paymentAssetInstance, DummyData.getOriginAssetPath(NATIVE_ADDRESS));
-
-        // Create a contract that will reject ETH transfers
-        RejectEther rejector = new RejectEther();
-
-        // Use the rejector as the target address
-        address rejectingTarget = address(rejector);
-
-        // Fund the test contract
-        vm.deal(address(this), amount);
-
-        // Expect revert due to failed transfer
-        vm.expectRevert(AssetManagement.NativePaymentFailed.selector);
-        zkpay.sendNative{value: amount}(onBehalfOf, rejectingTarget, memo);
-    }
-
-    function testSendNativeFeeTransferFailed() public {
-        address onBehalfOfAddr = address(0x123);
-        bytes32 onBehalfOf = bytes32(uint256(uint160(onBehalfOfAddr)));
-        uint64 itemId = 789;
-        bytes memory memo = abi.encode(itemId);
-        uint248 amount = 1 ether;
-
-        vm.prank(_owner);
-        zkpay.setPaymentAsset(NATIVE_ADDRESS, paymentAssetInstance, DummyData.getOriginAssetPath(NATIVE_ADDRESS));
-
-        RejectEther rejectingTreasury = new RejectEther();
-        vm.prank(_owner);
-        zkpay.setTreasury(address(rejectingTreasury));
-
-        vm.deal(address(this), amount);
-
-        vm.expectRevert(AssetManagement.NativePaymentFailed.selector);
-        zkpay.sendNative{value: amount}(onBehalfOf, address(0x456), memo);
-    }
-
     function testInitializeWithZeroSXTAddressReverts() public {
         address implementation = address(new ZKPay());
 


### PR DESCRIPTION
# Rationale for this change
Update both `send` and `query` to validate payment minimum price set by merchant against itemId. And remove `SendNative` method 

# What changes are included in this PR?
- add itemId param to Send method and its SendPayment event
- build itemId from clientContractCallbackAddress and function signature 
- require client's payment is equal or more min merchant' set item price.
- remove deprecated SendNative method and its tests.

# Are these changes tested?
Yes