### PR TITLE
chore: disable solhint `use-natspec` & `function-max-lines`

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -14,6 +14,8 @@
         "one-contract-per-file": "off",
         "no-complex-fallback": "off",
         "import-path-check": "off",
+        "use-natspec": "off",
+        "function-max-lines": "off",
         "func-visibility": [
             "warn",
             {


### PR DESCRIPTION
# Rationale for this change
currently Ci is broken due to new breaking change new releases of Solhint with default recommended rules. I propose disabling the follow rules for the moment to fix the Ci and if we see any strong reason of having any of them back, we can create an issue and handle them individually. 

 -  "use-natspec": because there is no direct way to disable it only for test files. currently we don't have netspecs for test files.
 -  "function-max-lines":  it's a rule of max 50 lines in a method
 
