### PR TITLE
refactor: remove `sendNative`

### DIFF
--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -248,21 +248,6 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
     }
 
     /// @inheritdoc IZKPay
-    function sendNative(bytes32 onBehalfOf, address target, bytes calldata memo) external payable nonReentrant {
-        if (msg.value > type(uint248).max) {
-            revert ValueExceedsUint248Limit();
-        }
-
-        uint248 amount = uint248(msg.value);
-
-        (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) =
-            _assets.send(NATIVE_ADDRESS, amount, target, _treasury, _sxt);
-        emit SendPayment(
-            NATIVE_ADDRESS, actualAmountReceived, protocolFeeAmount, onBehalfOf, target, memo, amountInUSD, msg.sender
-        );
-    }
-
-    /// @inheritdoc IZKPay
     function setMerchantConfig(MerchantLogic.MerchantConfig calldata config, bytes calldata path) external {
         _merchantConfigs.set(msg.sender, config);
         _swapLogicStorage.setMerchantTargetAssetPath(msg.sender, path);

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -135,12 +135,6 @@ interface IZKPay {
     /// @param memo Additional data or information about the payment
     function send(address asset, uint248 amount, bytes32 onBehalfOf, address target, bytes calldata memo) external;
 
-    /// @notice Allows for sending native tokens to a target address
-    /// @param onBehalfOf The identifier on whose behalf the payment is made
-    /// @param target The target address to receive the payment
-    /// @param memo Additional data or information about the payment
-    function sendNative(bytes32 onBehalfOf, address target, bytes calldata memo) external payable;
-
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct
     /// @param path The path for the target asset to swap to USDT (USDT => targetAsset)

--- a/test/PaymentFunctions.t.sol
+++ b/test/PaymentFunctions.t.sol
@@ -24,17 +24,6 @@ contract PaymentFunctionsTest is Test {
     address public onBehalfOf;
     bytes public memoBytes;
 
-    event SendPayment(
-        address indexed asset,
-        uint248 amount,
-        uint248 protocolFeeAmount,
-        bytes32 onBehalfOf,
-        address indexed target,
-        bytes memo,
-        uint248 amountInUSD,
-        address indexed sender
-    );
-
     function setUp() public {
         uint8 nativeTokenDecimals = 18;
         int256 nativeTokenPrice = 1000e8; // 1 ETH = $1000
@@ -159,43 +148,6 @@ contract PaymentFunctionsTest is Test {
         zkpay.send(address(usdc), usdcAmount, onBehalfOfBytes32, address(0), memoBytes);
     }
 
-    function testSendNative() public {
-        vm.deal(address(this), nativeAmount);
-
-        bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
-
-        // Expect the Payment event to be emitted with correct parameters
-        vm.expectEmit(true, true, true, false); // Don't check the amountInUSD
-        emit SendPayment(
-            NATIVE_ADDRESS,
-            nativeAmount,
-            uint248((uint256(nativeAmount) * 9000) / 1_000_000),
-            onBehalfOfBytes32,
-            targetProtocol,
-            memoBytes,
-            0,
-            address(this)
-        );
-
-        zkpay.sendNative{value: nativeAmount}(onBehalfOfBytes32, targetProtocol, memoBytes);
-
-        uint248 protocolFeeAmount = uint248((uint256(nativeAmount) * PROTOCOL_FEE) / PROTOCOL_FEE_PRECISION);
-        assertEq(targetProtocol.balance, nativeAmount - protocolFeeAmount);
-        assertEq(treasury.balance, protocolFeeAmount);
-    }
-
-    function testSendNativeToZeroAddres() public {
-        // Fund the test contract with ETH
-        vm.deal(address(this), nativeAmount);
-
-        // Convert onBehalfOf address to bytes32
-        bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
-
-        vm.expectRevert(AssetManagement.TargetAddressCannotBeZero.selector);
-        // Call the sendNative function
-        zkpay.sendNative{value: nativeAmount}(onBehalfOfBytes32, address(0), memoBytes);
-    }
-
     function testSendWithUnsupportedAsset() public {
         address invalidAsset = vm.addr(0x5);
 
@@ -223,29 +175,6 @@ contract PaymentFunctionsTest is Test {
 
         vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
         zkpay.send(newToken, usdcAmount, bytes32(uint256(uint160(onBehalfOf))), targetProtocol, memoBytes);
-    }
-
-    function testSendNativeWithUnsupportedPaymentType() public {
-        // Set up payment asset with unsupported payment type
-        AssetManagement.PaymentAsset memory paymentAssetInstance = AssetManagement.PaymentAsset({
-            allowedPaymentTypes: AssetManagement.QUERY_PAYMENT_FLAG, // Only query payments allowed
-            priceFeed: nativeTokenPriceFeed,
-            tokenDecimals: 18,
-            stalePriceThresholdInSeconds: 1000
-        });
-
-        vm.prank(owner);
-        zkpay.setPaymentAsset(NATIVE_ADDRESS, paymentAssetInstance, DummyData.getOriginAssetPath(NATIVE_ADDRESS));
-
-        // Convert onBehalfOf address to bytes32
-        bytes32 onBehalfOfBytes32 = bytes32(uint256(uint160(onBehalfOf)));
-
-        // Fund the test contract with ETH
-        vm.deal(address(this), nativeAmount);
-
-        // Expect revert because the asset doesn't support SEND payment type
-        vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
-        zkpay.sendNative{value: nativeAmount}(onBehalfOfBytes32, targetProtocol, memoBytes);
     }
 
     receive() external payable {}


### PR DESCRIPTION
## Summary
- Removed the `sendNative` function from the codebase as part of refactoring efforts

## Changes
- Eliminates unused/deprecated `sendNative` functionality
- Cleans up codebase by removing obsolete code paths

## Test plan
- Existing tests should continue to pass
- No breaking changes expected as this removes unused code