### PR TITLE
feat: add bytes32 `itemId` param to `Send` method

### DIFF
--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -57,6 +57,7 @@ interface IZKPay {
     /// @param memo Additional data or information about the payment
     /// @param amountInUSD The amount in USD
     /// @param sender The address that initiated the payment
+    /// @param itemId The item ID
     event SendPayment(
         address indexed asset,
         uint248 amount,
@@ -65,7 +66,8 @@ interface IZKPay {
         address indexed merchant,
         bytes memo,
         uint248 amountInUSD,
-        address indexed sender
+        address indexed sender,
+        bytes32 itemId
     );
 
     /// @notice Sets the treasury address
@@ -133,7 +135,15 @@ interface IZKPay {
     /// @param onBehalfOf The identifier on whose behalf the payment is made
     /// @param target The target address to receive the payment
     /// @param memo Additional data or information about the payment
-    function send(address asset, uint248 amount, bytes32 onBehalfOf, address target, bytes calldata memo) external;
+    /// @param itemId The item ID
+    function send(
+        address asset,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address target,
+        bytes calldata memo,
+        bytes32 itemId
+    ) external;
 
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct

--- a/test/FixedPriceFeed.t.sol
+++ b/test/FixedPriceFeed.t.sol
@@ -141,7 +141,7 @@ contract FixedPriceFeedTest is Test {
 
         // send
         vm.prank(payer);
-        zkpay.send(asset, amount, onBehalfOf, target, memo);
+        zkpay.send(asset, amount, onBehalfOf, target, memo, bytes32(0));
     }
 
     function testQueryWithFixedPriceFeed() public {
@@ -185,6 +185,7 @@ contract FixedPriceFeedTest is Test {
         MockERC20(asset).approve(address(zkpay), amount);
 
         // query
+        MockCustomLogic mockedCustomLogic = new MockCustomLogic();
         QueryLogic.QueryRequest memory queryRequest = QueryLogic.QueryRequest({
             query: "test",
             queryParameters: "test",
@@ -192,7 +193,7 @@ contract FixedPriceFeedTest is Test {
             callbackClientContractAddress: clientContractAddress,
             callbackGasLimit: 1000000,
             callbackData: "test",
-            customLogicContractAddress: address(this)
+            customLogicContractAddress: address(mockedCustomLogic)
         });
 
         // query

--- a/test/QueryCancelation.t.sol
+++ b/test/QueryCancelation.t.sol
@@ -10,6 +10,7 @@ import {AssetManagement} from "../src/libraries/AssetManagement.sol";
 import {QueryLogic} from "../src/libraries/QueryLogic.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {DummyData} from "./data/DummyData.sol";
+import {MockCustomLogic} from "./mocks/MockCustomLogic.sol";
 
 contract QueryCancelationTest is Test {
     ZKPay public _zkpay;
@@ -77,7 +78,7 @@ contract QueryCancelationTest is Test {
 
         vm.stopPrank();
 
-        address customLogicContractAddress = address(0x101);
+        MockCustomLogic mockedCustomLogic = new MockCustomLogic();
 
         // deploy custom logic contract
         _queryRequest = QueryLogic.QueryRequest({
@@ -87,7 +88,7 @@ contract QueryCancelationTest is Test {
             callbackClientContractAddress: address(this),
             callbackGasLimit: 1_000_000,
             callbackData: "test",
-            customLogicContractAddress: customLogicContractAddress
+            customLogicContractAddress: address(mockedCustomLogic)
         });
 
         // allow the zkpay contract to transfer usdc


### PR DESCRIPTION
# Rationale for this change
Update both `send` and `query` to validate payment minimum price set by merchant against itemId.

# What changes are included in this PR?
- add itemId param to Send method and its SendPayment event
- build itemId from clientContractCallbackAddress and function signature 
- require client's payment is equal or more min merchant' set item price.

# Are these changes tested?
Yes