### PR TITLE
feat: `authorize` payment for escrow payment

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+forge fmt --check 
 solhint "**/*.sol" -w 0
 slither ./
 slither . --config-file slither_openzeppelin.config.json

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -280,15 +280,14 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         bytes calldata memo,
         bytes32 itemId
     ) external nonReentrant returns (bytes32 transactionHash) {
-        EscrowPayment.Transaction memory transaction = EscrowPayment.Transaction({
-            asset: asset,
-            amount: amount,
-            from: address(uint160(uint256(onBehalfOf))),
-            to: merchant,
-            memo: memo,
-            itemId: itemId
-        });
+        uint248 actualAmountReceived = _assets.escrowPayment(asset, amount);
+
+        EscrowPayment.Transaction memory transaction =
+            EscrowPayment.Transaction({asset: asset, amount: actualAmountReceived, from: msg.sender, to: merchant});
+
         transactionHash = EscrowPayment.authorize(_escrowPaymentStorage, transaction);
+
+        emit Authorized(transaction, transactionHash, onBehalfOf, memo, itemId);
     }
 
     /// @inheritdoc IZKPay

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -279,7 +279,7 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         address merchant,
         bytes calldata memo,
         bytes32 itemId
-    ) external nonReentrant {
+    ) external nonReentrant returns (bytes32 transactionHash) {
         EscrowPayment.Transaction memory transaction = EscrowPayment.Transaction({
             asset: asset,
             amount: amount,
@@ -288,7 +288,7 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
             memo: memo,
             itemId: itemId
         });
-        EscrowPayment.authorize(_escrowPaymentStorage, transaction);
+        transactionHash = EscrowPayment.authorize(_escrowPaymentStorage, transaction);
     }
 
     /// @inheritdoc IZKPay

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -37,6 +37,7 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
     error SXTAddressCannotBeZero();
     error InsufficientPayment();
     error InvalidCallbackData();
+    error ZeroAmountReceived();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -281,6 +282,10 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         bytes32 itemId
     ) external nonReentrant returns (bytes32 transactionHash) {
         uint248 actualAmountReceived = _assets.escrowPayment(asset, amount);
+
+        if (actualAmountReceived == 0) {
+            revert ZeroAmountReceived();
+        }
 
         EscrowPayment.Transaction memory transaction =
             EscrowPayment.Transaction({asset: asset, amount: actualAmountReceived, from: msg.sender, to: merchant});

--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -281,10 +281,15 @@ contract ZKPay is ZKPayStorage, IZKPay, Initializable, OwnableUpgradeable, Reent
         bytes calldata memo,
         bytes32 itemId
     ) external nonReentrant returns (bytes32 transactionHash) {
-        uint248 actualAmountReceived = _assets.escrowPayment(asset, amount);
+        (uint248 actualAmountReceived, uint248 amountInUSD) = _assets.escrowPayment(asset, amount);
 
         if (actualAmountReceived == 0) {
             revert ZeroAmountReceived();
+        }
+
+        uint248 itemPrice = _paywallLogicStorage.getItemPrice(merchant, itemId);
+        if (amountInUSD < itemPrice) {
+            revert InsufficientPayment();
         }
 
         EscrowPayment.Transaction memory transaction =

--- a/src/ZKPayStorage.sol
+++ b/src/ZKPayStorage.sol
@@ -6,6 +6,7 @@ import {QueryLogic} from "./libraries/QueryLogic.sol";
 import {MerchantLogic} from "./libraries/MerchantLogic.sol";
 import {SwapLogic} from "./libraries/SwapLogic.sol";
 import {PayWallLogic} from "./libraries/PayWallLogic.sol";
+import {EscrowPayment} from "./libraries/EscrowPayment.sol";
 
 contract ZKPayStorage {
     address internal _treasury;
@@ -22,4 +23,7 @@ contract ZKPayStorage {
     SwapLogic.SwapLogicStorage internal _swapLogicStorage;
     // **  Paywall Logic Storage ** //
     PayWallLogic.PayWallLogicStorage internal _paywallLogicStorage;
+
+    // **  Escrow Payment Storage ** //
+    EscrowPayment.EscrowPaymentStorage internal _escrowPaymentStorage;
 }

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {AssetManagement} from "../libraries/AssetManagement.sol";
 import {QueryLogic} from "../libraries/QueryLogic.sol";
 import {MerchantLogic} from "../libraries/MerchantLogic.sol";
+import {EscrowPayment} from "../libraries/EscrowPayment.sol";
 
 interface IZKPay {
     /// @notice Emitted when the treasury address is set
@@ -68,6 +69,16 @@ interface IZKPay {
         uint248 amountInUSD,
         address indexed sender,
         bytes32 itemId
+    );
+
+    /// @notice Emitted when a payment is authorized
+    /// @param transaction The transaction that was authorized
+    /// @param transactionHash The hash of the transaction
+    /// @param onBehalfOf The identifier on whose behalf the payment is made
+    /// @param memo Additional data or information about the payment
+    /// @param itemId The item ID
+    event Authorized(
+        EscrowPayment.Transaction transaction, bytes32 transactionHash, bytes32 onBehalfOf, bytes memo, bytes32 itemId
     );
 
     /// @notice Sets the treasury address
@@ -150,6 +161,7 @@ interface IZKPay {
     /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
     /// @param asset The address of the ERC20 token to send
     /// @param amount The amount of tokens to send
+    /// @param onBehalfOf The identifier on whose behalf the payment is made
     /// @param merchant The merchant address
     /// @param memo Additional data or information about the payment
     /// @param itemId The item ID

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -153,6 +153,7 @@ interface IZKPay {
     /// @param merchant The merchant address
     /// @param memo Additional data or information about the payment
     /// @param itemId The item ID
+    /// @return transactionHash The hash of the transaction
     function authorize(
         address asset,
         uint248 amount,
@@ -160,7 +161,7 @@ interface IZKPay {
         address merchant,
         bytes calldata memo,
         bytes32 itemId
-    ) external;
+    ) external returns (bytes32 transactionHash);
 
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -145,6 +145,23 @@ interface IZKPay {
         bytes32 itemId
     ) external;
 
+    /// @notice Authorizes a payment to a target address
+    /// the payment will be pulled from `msg.sender` and held in ZKpay contract as escrow
+    /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
+    /// @param asset The address of the ERC20 token to send
+    /// @param amount The amount of tokens to send
+    /// @param merchant The merchant address
+    /// @param memo Additional data or information about the payment
+    /// @param itemId The item ID
+    function authorize(
+        address asset,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address merchant,
+        bytes calldata memo,
+        bytes32 itemId
+    ) external;
+
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct
     /// @param path The path for the target asset to swap to USDT (USDT => targetAsset)

--- a/src/libraries/AssetManagement.sol
+++ b/src/libraries/AssetManagement.sol
@@ -321,7 +321,7 @@ library AssetManagement {
     /// @return actualAmountReceived The actual amount received by the contract.
     function escrowPayment(mapping(address asset => PaymentAsset) storage _assets, address asset, uint248 amount)
         internal
-        returns (uint248 actualAmountReceived)
+        returns (uint248 actualAmountReceived, uint248 amountInUSD)
     {
         if (!isSupported(_assets, asset, PaymentType.Send)) {
             revert AssetIsNotSupportedForThisMethod();
@@ -332,5 +332,6 @@ library AssetManagement {
         uint256 balanceAfter = IERC20(asset).balanceOf(address(this));
 
         actualAmountReceived = uint248(balanceAfter - balanceBefore);
+        amountInUSD = convertToUsd(_assets, asset, actualAmountReceived);
     }
 }

--- a/src/libraries/AssetManagement.sol
+++ b/src/libraries/AssetManagement.sol
@@ -313,4 +313,24 @@ library AssetManagement {
 
         amountInUSD = convertToUsd(_assets, asset, actualAmountReceived);
     }
+
+    /// @notice Escrows a payment by transferring it from the sender to the contract
+    /// @param _assets The mapping of assets to their payment information.
+    /// @param asset The address of the asset to escrow the payment for.
+    /// @param amount The amount of the asset to escrow.
+    /// @return actualAmountReceived The actual amount received by the contract.
+    function escrowPayment(mapping(address asset => PaymentAsset) storage _assets, address asset, uint248 amount)
+        internal
+        returns (uint248 actualAmountReceived)
+    {
+        if (!isSupported(_assets, asset, PaymentType.Send)) {
+            revert AssetIsNotSupportedForThisMethod();
+        }
+
+        uint256 balanceBefore = IERC20(asset).balanceOf(address(this));
+        SafeERC20.safeTransferFrom(IERC20(asset), msg.sender, address(this), amount);
+        uint256 balanceAfter = IERC20(asset).balanceOf(address(this));
+
+        actualAmountReceived = uint248(balanceAfter - balanceBefore);
+    }
 }

--- a/src/libraries/EscrowPayment.sol
+++ b/src/libraries/EscrowPayment.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @title EscrowPayment
+library EscrowPayment {
+    event Authorized(Transaction transaction, uint248 nonce, bytes32 transactionHash);
+
+    /// @notice Transaction struct
+    /// @dev The transaction struct is not meant to be stored
+    // solhint-disable-next-line gas-struct-packing
+    struct Transaction {
+        /// @notice The asset being transferred
+        address asset;
+        /// @notice The amount of the source asset
+        uint248 amount;
+        /// @notice The address of the sender
+        address from;
+        /// @notice The address of the receiver
+        address to;
+        /// @notice The memo of the transaction
+        bytes memo;
+        /// @notice The item ID
+        bytes32 itemId;
+    }
+
+    struct EscrowPaymentStorage {
+        uint248 nonce;
+        mapping(bytes32 transactionHash => uint248 transactionNonce) transactionNonces;
+    }
+
+    modifier incrementNonce(EscrowPaymentStorage storage escrowPaymentStorage) {
+        ++escrowPaymentStorage.nonce;
+        _;
+    }
+
+    function authorize(EscrowPaymentStorage storage escrowPaymentStorage, Transaction memory transaction)
+        internal
+        incrementNonce(escrowPaymentStorage)
+    {
+        bytes32 transactionHash = keccak256(abi.encode(transaction, escrowPaymentStorage.nonce, block.chainid));
+        escrowPaymentStorage.transactionNonces[transactionHash] = escrowPaymentStorage.nonce;
+
+        emit Authorized(transaction, escrowPaymentStorage.nonce, transactionHash);
+    }
+}

--- a/src/libraries/EscrowPayment.sol
+++ b/src/libraries/EscrowPayment.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.28;
 
 /// @title EscrowPayment
 library EscrowPayment {
-    event Authorized(Transaction transaction, uint248 nonce, bytes32 transactionHash);
-
     /// @notice Transaction struct
     /// @dev The transaction struct is not meant to be stored
     // solhint-disable-next-line gas-struct-packing
@@ -17,10 +15,6 @@ library EscrowPayment {
         address from;
         /// @notice The address of the receiver
         address to;
-        /// @notice The memo of the transaction
-        bytes memo;
-        /// @notice The item ID
-        bytes32 itemId;
     }
 
     struct EscrowPaymentStorage {
@@ -37,6 +31,14 @@ library EscrowPayment {
         _;
     }
 
+    /// @notice Generates the transaction hash
+    /// @param nonce Nonce of the transaction
+    /// @param transaction The transaction to generate the hash for
+    /// @return transactionHash The hash of the transaction
+    function generateTransactionHash(Transaction memory transaction, uint248 nonce) internal view returns (bytes32) {
+        return keccak256(abi.encode(transaction, nonce, block.chainid));
+    }
+
     /// @notice Authorizes a transaction
     /// @param escrowPaymentStorage The storage of the escrow payment
     /// @param transaction The transaction to authorize
@@ -46,9 +48,7 @@ library EscrowPayment {
         incrementNonce(escrowPaymentStorage)
         returns (bytes32 transactionHash)
     {
-        transactionHash = keccak256(abi.encode(transaction, escrowPaymentStorage.nonce, block.chainid));
+        transactionHash = generateTransactionHash(transaction, escrowPaymentStorage.nonce);
         escrowPaymentStorage.transactionNonces[transactionHash] = escrowPaymentStorage.nonce;
-
-        emit Authorized(transaction, escrowPaymentStorage.nonce, transactionHash);
     }
 }

--- a/src/libraries/EscrowPayment.sol
+++ b/src/libraries/EscrowPayment.sol
@@ -24,20 +24,29 @@ library EscrowPayment {
     }
 
     struct EscrowPaymentStorage {
+        /// @notice Global nonce for the escrow payment
         uint248 nonce;
+        /// @notice Mapping of transaction hashes to their nonces, if nonce is 0, the transaction is not authorized
         mapping(bytes32 transactionHash => uint248 transactionNonce) transactionNonces;
     }
 
+    /// @notice Increments the global nonce for the escrow payment
+    /// @param escrowPaymentStorage The storage of the escrow payment
     modifier incrementNonce(EscrowPaymentStorage storage escrowPaymentStorage) {
         ++escrowPaymentStorage.nonce;
         _;
     }
 
+    /// @notice Authorizes a transaction
+    /// @param escrowPaymentStorage The storage of the escrow payment
+    /// @param transaction The transaction to authorize
+    /// @return transactionHash The hash of the transaction
     function authorize(EscrowPaymentStorage storage escrowPaymentStorage, Transaction memory transaction)
         internal
         incrementNonce(escrowPaymentStorage)
+        returns (bytes32 transactionHash)
     {
-        bytes32 transactionHash = keccak256(abi.encode(transaction, escrowPaymentStorage.nonce, block.chainid));
+        transactionHash = keccak256(abi.encode(transaction, escrowPaymentStorage.nonce, block.chainid));
         escrowPaymentStorage.transactionNonces[transactionHash] = escrowPaymentStorage.nonce;
 
         emit Authorized(transaction, escrowPaymentStorage.nonce, transactionHash);

--- a/test/ZKPay.t.sol
+++ b/test/ZKPay.t.sol
@@ -319,8 +319,8 @@ contract ZKPayTest is Test, IZKPayClient {
 
     function _setupMockTokenForAuthorize(uint248 amount) internal returns (MockERC20) {
         MockERC20 mockToken = new MockERC20();
-        mockToken.mint(address(this), amount * 10);
-        mockToken.approve(address(zkpay), amount * 10);
+        mockToken.mint(address(this), amount);
+        mockToken.approve(address(zkpay), amount);
 
         vm.prank(_owner);
         zkpay.setPaymentAsset(
@@ -594,7 +594,7 @@ contract ZKPayTest is Test, IZKPayClient {
         bytes memory memo = "test payment";
         bytes32 itemId = bytes32("item123");
 
-        MockERC20 mockToken = _setupMockTokenForAuthorize(amount);
+        MockERC20 mockToken = _setupMockTokenForAuthorize(amount * 4);
 
         zkpay.authorize(address(mockToken), amount, onBehalfOf, merchant, memo, itemId);
         zkpay.authorize(address(mockToken), amount, onBehalfOf, merchant, memo, itemId);
@@ -619,6 +619,12 @@ contract ZKPayTest is Test, IZKPayClient {
         bytes32 itemId = bytes32(0);
 
         MockERC20 mockToken = _setupMockTokenForAuthorize(amount);
+
+        vm.expectRevert(ZKPay.ZeroAmountReceived.selector);
+        zkpay.authorize(address(mockToken), amount, onBehalfOf, merchant, memo, itemId);
+
+        amount = 1;
+        mockToken = _setupMockTokenForAuthorize(amount);
 
         EscrowPayment.Transaction memory expectedTransaction =
             EscrowPayment.Transaction({asset: address(mockToken), amount: amount, from: address(this), to: merchant});
@@ -728,7 +734,7 @@ contract ZKPayTest is Test, IZKPayClient {
         bytes memory memo = "test payment";
         bytes32 itemId = bytes32("item123");
 
-        MockERC20 mockToken = _setupMockTokenForAuthorize(amount);
+        MockERC20 mockToken = _setupMockTokenForAuthorize(amount * 2);
 
         EscrowPayment.Transaction memory expectedTransaction =
             EscrowPayment.Transaction({asset: address(mockToken), amount: amount, from: address(this), to: merchant});
@@ -783,7 +789,7 @@ contract ZKPayTest is Test, IZKPayClient {
         bytes calldata memo,
         bytes32 itemId
     ) public {
-        vm.assume(amount > 0 && amount < type(uint248).max / 10);
+        vm.assume(amount > 0 && amount < type(uint248).max);
 
         MockERC20 mockToken = _setupMockTokenForAuthorize(amount);
 

--- a/test/libraries/AssetManagement.t.sol
+++ b/test/libraries/AssetManagement.t.sol
@@ -89,6 +89,10 @@ contract AssetManagementTestWrapper {
     function convertNativeToToken(address nativeTokenAddress, uint248 nativeAmount) external view returns (uint248) {
         return AssetManagement.convertNativeToToken(_assets, nativeTokenAddress, nativeAmount);
     }
+
+    function escrowPayment(address asset, uint248 amount) external returns (uint248) {
+        return AssetManagement.escrowPayment(_assets, asset, amount);
+    }
 }
 
 contract AssetManagementTest is Test {
@@ -390,5 +394,129 @@ contract AssetManagementTest is Test {
 
         MockIncompleteRoundDataAggregator mockIncomplete = new MockIncompleteRoundDataAggregator();
         assertTrue(mockIncomplete.dummy());
+    }
+
+    function testEscrowPayment() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248 escrowAmount = 1000 ether;
+        mockToken.mint(address(this), escrowAmount);
+
+        mockToken.approve(address(_wrapper), escrowAmount);
+
+        uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
+        uint256 initialUserBalance = mockToken.balanceOf(address(this));
+
+        uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+
+        uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
+        uint256 finalUserBalance = mockToken.balanceOf(address(this));
+
+        assertEq(actualAmountReceived, escrowAmount);
+        assertEq(finalContractBalance, initialContractBalance + escrowAmount);
+        assertEq(finalUserBalance, initialUserBalance - escrowAmount);
+    }
+
+    function testEscrowPaymentWithDifferentAmounts() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248[] memory testAmounts = new uint248[](3);
+        testAmounts[0] = 1 ether;
+        testAmounts[1] = 500 ether;
+        testAmounts[2] = 1000000 ether;
+
+        uint256 length = testAmounts.length;
+
+        for (uint256 i = 0; i < length; ++i) {
+            uint248 escrowAmount = testAmounts[i];
+
+            mockToken.mint(address(this), escrowAmount);
+            mockToken.approve(address(_wrapper), escrowAmount);
+
+            uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
+
+            uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+
+            uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
+
+            assertEq(actualAmountReceived, escrowAmount);
+            assertEq(finalContractBalance, initialContractBalance + escrowAmount);
+        }
+    }
+
+    function testEscrowPaymentUnsupportedAsset() public {
+        address unsupportedAsset = address(0x9999);
+        uint248 escrowAmount = 1000e18;
+
+        vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
+        _wrapper.escrowPayment(unsupportedAsset, escrowAmount);
+    }
+
+    function testEscrowPaymentQueryOnlyAsset() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.QUERY_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248 escrowAmount = 1000e18;
+
+        vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
+        _wrapper.escrowPayment(tokenAddress, escrowAmount);
+    }
+
+    function testEscrowPaymentZeroAmount() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        mockToken.mint(address(this), 1000e18);
+        mockToken.approve(address(_wrapper), 1000e18);
+
+        uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, 0);
+
+        assertEq(actualAmountReceived, 0);
     }
 }

--- a/test/libraries/AssetManagement.t.sol
+++ b/test/libraries/AssetManagement.t.sol
@@ -90,7 +90,7 @@ contract AssetManagementTestWrapper {
         return AssetManagement.convertNativeToToken(_assets, nativeTokenAddress, nativeAmount);
     }
 
-    function escrowPayment(address asset, uint248 amount) external returns (uint248) {
+    function escrowPayment(address asset, uint248 amount) external returns (uint248, uint248) {
         return AssetManagement.escrowPayment(_assets, asset, amount);
     }
 }
@@ -419,7 +419,7 @@ contract AssetManagementTest is Test {
         uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
         uint256 initialUserBalance = mockToken.balanceOf(address(this));
 
-        uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+        (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, escrowAmount);
 
         uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
         uint256 finalUserBalance = mockToken.balanceOf(address(this));
@@ -459,7 +459,7 @@ contract AssetManagementTest is Test {
 
             uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
 
-            uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+            (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, escrowAmount);
 
             uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
 
@@ -515,7 +515,7 @@ contract AssetManagementTest is Test {
         mockToken.mint(address(this), 1000e18);
         mockToken.approve(address(_wrapper), 1000e18);
 
-        uint248 actualAmountReceived = _wrapper.escrowPayment(tokenAddress, 0);
+        (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, 0);
 
         assertEq(actualAmountReceived, 0);
     }

--- a/test/libraries/EscrowPayment.t.sol
+++ b/test/libraries/EscrowPayment.t.sol
@@ -43,9 +43,7 @@ contract EscrowPaymentTest is Test {
             asset: address(0x1234),
             amount: 1000,
             from: address(0x5678),
-            to: address(0x9abc),
-            memo: "test payment",
-            itemId: bytes32("item123")
+            to: address(0x9abc)
         });
     }
 
@@ -56,9 +54,6 @@ contract EscrowPaymentTest is Test {
     function testAuthorizeBasic() public {
         uint248 expectedNonce = 1;
         bytes32 expectedHash = _wrapper.generateTransactionHash(_sampleTransaction, expectedNonce);
-
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(_sampleTransaction, expectedNonce, expectedHash);
 
         _wrapper.authorize(_sampleTransaction);
 
@@ -78,33 +73,16 @@ contract EscrowPaymentTest is Test {
     }
 
     function testAuthorizeMultipleTransactions() public {
-        EscrowPayment.Transaction memory transaction1 = EscrowPayment.Transaction({
-            asset: address(0x1111),
-            amount: 100,
-            from: address(0x2222),
-            to: address(0x3333),
-            memo: "tx1",
-            itemId: bytes32("item1")
-        });
+        EscrowPayment.Transaction memory transaction1 =
+            EscrowPayment.Transaction({asset: address(0x1111), amount: 100, from: address(0x2222), to: address(0x3333)});
 
-        EscrowPayment.Transaction memory transaction2 = EscrowPayment.Transaction({
-            asset: address(0x4444),
-            amount: 200,
-            from: address(0x5555),
-            to: address(0x6666),
-            memo: "tx2",
-            itemId: bytes32("item2")
-        });
+        EscrowPayment.Transaction memory transaction2 =
+            EscrowPayment.Transaction({asset: address(0x4444), amount: 200, from: address(0x5555), to: address(0x6666)});
 
         bytes32 hash1 = _wrapper.generateTransactionHash(transaction1, 1);
         bytes32 hash2 = _wrapper.generateTransactionHash(transaction2, 2);
 
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(transaction1, 1, hash1);
         _wrapper.authorize(transaction1);
-
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(transaction2, 2, hash2);
         _wrapper.authorize(transaction2);
 
         assertEq(_wrapper.getNonce(), 2);
@@ -131,19 +109,10 @@ contract EscrowPaymentTest is Test {
     }
 
     function testAuthorizeWithZeroValues() public {
-        EscrowPayment.Transaction memory zeroTransaction = EscrowPayment.Transaction({
-            asset: address(0),
-            amount: 0,
-            from: address(0),
-            to: address(0),
-            memo: "",
-            itemId: bytes32(0)
-        });
+        EscrowPayment.Transaction memory zeroTransaction =
+            EscrowPayment.Transaction({asset: address(0), amount: 0, from: address(0), to: address(0)});
 
         bytes32 expectedHash = _wrapper.generateTransactionHash(zeroTransaction, 1);
-
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(zeroTransaction, 1, expectedHash);
 
         _wrapper.authorize(zeroTransaction);
 
@@ -157,42 +126,12 @@ contract EscrowPaymentTest is Test {
             asset: address(type(uint160).max),
             amount: type(uint248).max,
             from: address(type(uint160).max),
-            to: address(type(uint160).max),
-            memo: "maximum length memo that could be very long",
-            itemId: bytes32(type(uint256).max)
+            to: address(type(uint160).max)
         });
 
         bytes32 expectedHash = _wrapper.generateTransactionHash(maxTransaction, 1);
 
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(maxTransaction, 1, expectedHash);
-
         _wrapper.authorize(maxTransaction);
-
-        assertEq(_wrapper.getNonce(), 1);
-        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
-    }
-
-    function testAuthorizeWithLongMemo() public {
-        // solhint-disable-next-line gas-small-strings
-        string memory longMemo =
-            "This is a very long memo that contains a lot of text to test the handling of long memo fields in the transaction structure and to ensure it works correctly with the authorization process";
-
-        EscrowPayment.Transaction memory longMemoTransaction = EscrowPayment.Transaction({
-            asset: address(0x1234),
-            amount: 5000,
-            from: address(0x5678),
-            to: address(0x9abc),
-            memo: bytes(longMemo),
-            itemId: bytes32("longmemo")
-        });
-
-        bytes32 expectedHash = _wrapper.generateTransactionHash(longMemoTransaction, 1);
-
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(longMemoTransaction, 1, expectedHash);
-
-        _wrapper.authorize(longMemoTransaction);
 
         assertEq(_wrapper.getNonce(), 1);
         assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
@@ -208,9 +147,7 @@ contract EscrowPaymentTest is Test {
             asset: address(0x1234),
             amount: 2000,
             from: address(0x5678),
-            to: address(0x9abc),
-            memo: "test payment",
-            itemId: bytes32("item123")
+            to: address(0x9abc)
         });
 
         bytes32 hash3 = _wrapper.generateTransactionHash(differentTransaction, 1);
@@ -227,21 +164,11 @@ contract EscrowPaymentTest is Test {
         _wrapper.authorize(_sampleTransaction);
     }
 
-    function testFuzzAuthorize(
-        address asset,
-        uint248 amount,
-        address from,
-        address to,
-        bytes calldata memo,
-        bytes32 itemId
-    ) public {
+    function testFuzzAuthorize(address asset, uint248 amount, address from, address to) public {
         EscrowPayment.Transaction memory fuzzTransaction =
-            EscrowPayment.Transaction({asset: asset, amount: amount, from: from, to: to, memo: memo, itemId: itemId});
+            EscrowPayment.Transaction({asset: asset, amount: amount, from: from, to: to});
 
         bytes32 expectedHash = _wrapper.generateTransactionHash(fuzzTransaction, 1);
-
-        vm.expectEmit(true, true, true, true);
-        emit EscrowPayment.Authorized(fuzzTransaction, 1, expectedHash);
 
         _wrapper.authorize(fuzzTransaction);
 

--- a/test/libraries/EscrowPayment.t.sol
+++ b/test/libraries/EscrowPayment.t.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {EscrowPayment} from "../../src/libraries/EscrowPayment.sol";
+
+contract EscrowPaymentWrapper {
+    EscrowPayment.EscrowPaymentStorage internal _escrowPaymentStorage;
+
+    function authorize(EscrowPayment.Transaction calldata transaction) external {
+        EscrowPayment.authorize(_escrowPaymentStorage, transaction);
+    }
+
+    function getNonce() external view returns (uint248) {
+        return _escrowPaymentStorage.nonce;
+    }
+
+    function getTransactionNonce(bytes32 transactionHash) external view returns (uint248) {
+        return _escrowPaymentStorage.transactionNonces[transactionHash];
+    }
+
+    function generateTransactionHash(EscrowPayment.Transaction calldata transaction, uint248 nonce)
+        external
+        view
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(transaction, nonce, block.chainid));
+    }
+
+    function setNonce(uint248 nonce) external {
+        _escrowPaymentStorage.nonce = nonce;
+    }
+}
+
+contract EscrowPaymentTest is Test {
+    EscrowPaymentWrapper internal _wrapper;
+    EscrowPayment.Transaction internal _sampleTransaction;
+
+    function setUp() public {
+        _wrapper = new EscrowPaymentWrapper();
+
+        _sampleTransaction = EscrowPayment.Transaction({
+            asset: address(0x1234),
+            amount: 1000,
+            from: address(0x5678),
+            to: address(0x9abc),
+            memo: "test payment",
+            itemId: bytes32("item123")
+        });
+    }
+
+    function testInitialState() public view {
+        assertEq(_wrapper.getNonce(), 0);
+    }
+
+    function testAuthorizeBasic() public {
+        uint248 expectedNonce = 1;
+        bytes32 expectedHash = _wrapper.generateTransactionHash(_sampleTransaction, expectedNonce);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(_sampleTransaction, expectedNonce, expectedHash);
+
+        _wrapper.authorize(_sampleTransaction);
+
+        assertEq(_wrapper.getNonce(), expectedNonce);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), expectedNonce);
+    }
+
+    function testAuthorizeIncrementsNonce() public {
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 1);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 2);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 3);
+    }
+
+    function testAuthorizeMultipleTransactions() public {
+        EscrowPayment.Transaction memory transaction1 = EscrowPayment.Transaction({
+            asset: address(0x1111),
+            amount: 100,
+            from: address(0x2222),
+            to: address(0x3333),
+            memo: "tx1",
+            itemId: bytes32("item1")
+        });
+
+        EscrowPayment.Transaction memory transaction2 = EscrowPayment.Transaction({
+            asset: address(0x4444),
+            amount: 200,
+            from: address(0x5555),
+            to: address(0x6666),
+            memo: "tx2",
+            itemId: bytes32("item2")
+        });
+
+        bytes32 hash1 = _wrapper.generateTransactionHash(transaction1, 1);
+        bytes32 hash2 = _wrapper.generateTransactionHash(transaction2, 2);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(transaction1, 1, hash1);
+        _wrapper.authorize(transaction1);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(transaction2, 2, hash2);
+        _wrapper.authorize(transaction2);
+
+        assertEq(_wrapper.getNonce(), 2);
+        assertEq(_wrapper.getTransactionNonce(hash1), 1);
+        assertEq(_wrapper.getTransactionNonce(hash2), 2);
+    }
+
+    function testAuthorizeWithDifferentChainId() public {
+        uint256 originalChainId = block.chainid;
+
+        bytes32 hash1 = _wrapper.generateTransactionHash(_sampleTransaction, 1);
+        _wrapper.authorize(_sampleTransaction);
+
+        vm.chainId(999);
+
+        bytes32 hash2 = _wrapper.generateTransactionHash(_sampleTransaction, 2);
+        _wrapper.authorize(_sampleTransaction);
+
+        assertNotEq(hash1, hash2);
+        assertEq(_wrapper.getTransactionNonce(hash1), 1);
+        assertEq(_wrapper.getTransactionNonce(hash2), 2);
+
+        vm.chainId(originalChainId);
+    }
+
+    function testAuthorizeWithZeroValues() public {
+        EscrowPayment.Transaction memory zeroTransaction = EscrowPayment.Transaction({
+            asset: address(0),
+            amount: 0,
+            from: address(0),
+            to: address(0),
+            memo: "",
+            itemId: bytes32(0)
+        });
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(zeroTransaction, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(zeroTransaction, 1, expectedHash);
+
+        _wrapper.authorize(zeroTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+
+    function testAuthorizeWithMaxValues() public {
+        // solhint-disable-next-line gas-small-strings
+        EscrowPayment.Transaction memory maxTransaction = EscrowPayment.Transaction({
+            asset: address(type(uint160).max),
+            amount: type(uint248).max,
+            from: address(type(uint160).max),
+            to: address(type(uint160).max),
+            memo: "maximum length memo that could be very long",
+            itemId: bytes32(type(uint256).max)
+        });
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(maxTransaction, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(maxTransaction, 1, expectedHash);
+
+        _wrapper.authorize(maxTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+
+    function testAuthorizeWithLongMemo() public {
+        // solhint-disable-next-line gas-small-strings
+        string memory longMemo =
+            "This is a very long memo that contains a lot of text to test the handling of long memo fields in the transaction structure and to ensure it works correctly with the authorization process";
+
+        EscrowPayment.Transaction memory longMemoTransaction = EscrowPayment.Transaction({
+            asset: address(0x1234),
+            amount: 5000,
+            from: address(0x5678),
+            to: address(0x9abc),
+            memo: bytes(longMemo),
+            itemId: bytes32("longmemo")
+        });
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(longMemoTransaction, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(longMemoTransaction, 1, expectedHash);
+
+        _wrapper.authorize(longMemoTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+
+    function testTransactionHashUniqueness() public view {
+        bytes32 hash1 = _wrapper.generateTransactionHash(_sampleTransaction, 1);
+        bytes32 hash2 = _wrapper.generateTransactionHash(_sampleTransaction, 2);
+
+        assertNotEq(hash1, hash2);
+
+        EscrowPayment.Transaction memory differentTransaction = EscrowPayment.Transaction({
+            asset: address(0x1234),
+            amount: 2000,
+            from: address(0x5678),
+            to: address(0x9abc),
+            memo: "test payment",
+            itemId: bytes32("item123")
+        });
+
+        bytes32 hash3 = _wrapper.generateTransactionHash(differentTransaction, 1);
+        assertNotEq(hash1, hash3);
+    }
+
+    function testNonceOverflow() public {
+        _wrapper.setNonce(type(uint248).max - 1);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), type(uint248).max);
+
+        vm.expectRevert();
+        _wrapper.authorize(_sampleTransaction);
+    }
+
+    function testFuzzAuthorize(
+        address asset,
+        uint248 amount,
+        address from,
+        address to,
+        bytes calldata memo,
+        bytes32 itemId
+    ) public {
+        EscrowPayment.Transaction memory fuzzTransaction =
+            EscrowPayment.Transaction({asset: asset, amount: amount, from: from, to: to, memo: memo, itemId: itemId});
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(fuzzTransaction, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit EscrowPayment.Authorized(fuzzTransaction, 1, expectedHash);
+
+        _wrapper.authorize(fuzzTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+}


### PR DESCRIPTION
# Rationale for this change
Enable ZKpay to escrow payments so merchant can pull them when settled. (that will be in a follow-up PR) 
NOTE: this doesn't involve token movements yet. that to be build in a different PR. 

This has been splitted into smaller PRs: #19, #20, #21, #22

# What changes are included in this PR?
- added new `EscrowPayment.sol` library. 
- extend ZKpay with `authorize` external method.

# Are these changes tested?
Yes
