### PR TITLE
feat: pull asset with `escrowPayment` method

### DIFF
--- a/src/libraries/AssetManagement.sol
+++ b/src/libraries/AssetManagement.sol
@@ -276,6 +276,30 @@ library AssetManagement {
         tokenAmount = convertUsdToToken(_assets, asset, usdValue);
     }
 
+    /// @dev Pulls `amount` of `asset` from msg.sender to `to`,
+    /// measures the real amount received (fee-on-transfer tokens),
+    /// and converts it to USD.
+    /// Reverts if the asset isn’t supported for the given payment type.
+    function _pullAndQuote(
+        mapping(address asset => PaymentAsset) storage _assets,
+        address asset,
+        address to,
+        uint248 amount,
+        PaymentType paymentType
+    ) internal returns (uint248 actualAmountReceived, uint248 amountInUSD) {
+        if (!isSupported(_assets, asset, paymentType)) {
+            revert AssetIsNotSupportedForThisMethod();
+        }
+
+        IERC20 token = IERC20(asset);
+        uint256 beforeBalance = token.balanceOf(to);
+        SafeERC20.safeTransferFrom(token, msg.sender, to, amount);
+        uint256 afterBalance = token.balanceOf(to);
+
+        actualAmountReceived = uint248(afterBalance - beforeBalance);
+        amountInUSD = convertToUsd(_assets, asset, actualAmountReceived);
+    }
+
     /// @notice Sends a payment to a target address.
     /// @param _assets The mapping of assets to their payment information.
     /// @param asset The address of the asset to send the payment for.
@@ -291,26 +315,28 @@ library AssetManagement {
         address treasury,
         address sxt
     ) internal returns (uint248 actualAmountReceived, uint248 amountInUSD, uint248 protocolFeeAmount) {
-        if (merchant == ZERO_ADDRESS) {
-            revert MerchantAddressCannotBeZero();
-        }
-
-        if (!isSupported(_assets, asset, PaymentType.Send)) {
-            revert AssetIsNotSupportedForThisMethod();
-        }
+        if (merchant == ZERO_ADDRESS) revert MerchantAddressCannotBeZero();
 
         protocolFeeAmount = asset == sxt ? 0 : uint248((uint256(amount) * PROTOCOL_FEE) / PROTOCOL_FEE_PRECISION);
+
         uint248 transferAmount = amount - protocolFeeAmount;
 
-        uint256 balanceBefore = IERC20(asset).balanceOf(merchant);
+        (actualAmountReceived, amountInUSD) = _pullAndQuote(_assets, asset, merchant, transferAmount, PaymentType.Send);
+
         if (protocolFeeAmount > 0) {
             SafeERC20.safeTransferFrom(IERC20(asset), msg.sender, treasury, protocolFeeAmount);
         }
-        SafeERC20.safeTransferFrom(IERC20(asset), msg.sender, merchant, transferAmount);
-        uint256 balanceAfter = IERC20(asset).balanceOf(merchant);
+    }
 
-        actualAmountReceived = uint248(balanceAfter - balanceBefore);
-
-        amountInUSD = convertToUsd(_assets, asset, actualAmountReceived);
+    /// @notice Escrows a payment by transferring it from the sender to the contract
+    /// @param _assets The mapping of assets to their payment information.
+    /// @param asset The address of the asset to escrow the payment for.
+    /// @param amount The amount of the asset to escrow.
+    /// @return actualAmountReceived The actual amount received by the contract.
+    function escrowPayment(mapping(address asset => PaymentAsset) storage _assets, address asset, uint248 amount)
+        internal
+        returns (uint248 actualAmountReceived, uint248 amountInUSD)
+    {
+        (actualAmountReceived, amountInUSD) = _pullAndQuote(_assets, asset, address(this), amount, PaymentType.Send);
     }
 }

--- a/test/libraries/AssetManagement.t.sol
+++ b/test/libraries/AssetManagement.t.sol
@@ -89,6 +89,10 @@ contract AssetManagementTestWrapper {
     function convertNativeToToken(address nativeTokenAddress, uint248 nativeAmount) external view returns (uint248) {
         return AssetManagement.convertNativeToToken(_assets, nativeTokenAddress, nativeAmount);
     }
+
+    function escrowPayment(address asset, uint248 amount) external returns (uint248, uint248) {
+        return AssetManagement.escrowPayment(_assets, asset, amount);
+    }
 }
 
 contract AssetManagementTest is Test {
@@ -390,5 +394,129 @@ contract AssetManagementTest is Test {
 
         MockIncompleteRoundDataAggregator mockIncomplete = new MockIncompleteRoundDataAggregator();
         assertTrue(mockIncomplete.dummy());
+    }
+
+    function testEscrowPayment() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248 escrowAmount = 1000 ether;
+        mockToken.mint(address(this), escrowAmount);
+
+        mockToken.approve(address(_wrapper), escrowAmount);
+
+        uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
+        uint256 initialUserBalance = mockToken.balanceOf(address(this));
+
+        (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+
+        uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
+        uint256 finalUserBalance = mockToken.balanceOf(address(this));
+
+        assertEq(actualAmountReceived, escrowAmount);
+        assertEq(finalContractBalance, initialContractBalance + escrowAmount);
+        assertEq(finalUserBalance, initialUserBalance - escrowAmount);
+    }
+
+    function testEscrowPaymentWithDifferentAmounts() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248[] memory testAmounts = new uint248[](3);
+        testAmounts[0] = 1 ether;
+        testAmounts[1] = 500 ether;
+        testAmounts[2] = 1000000 ether;
+
+        uint256 length = testAmounts.length;
+
+        for (uint256 i = 0; i < length; ++i) {
+            uint248 escrowAmount = testAmounts[i];
+
+            mockToken.mint(address(this), escrowAmount);
+            mockToken.approve(address(_wrapper), escrowAmount);
+
+            uint256 initialContractBalance = mockToken.balanceOf(address(_wrapper));
+
+            (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, escrowAmount);
+
+            uint256 finalContractBalance = mockToken.balanceOf(address(_wrapper));
+
+            assertEq(actualAmountReceived, escrowAmount);
+            assertEq(finalContractBalance, initialContractBalance + escrowAmount);
+        }
+    }
+
+    function testEscrowPaymentUnsupportedAsset() public {
+        address unsupportedAsset = address(0x9999);
+        uint248 escrowAmount = 1000e18;
+
+        vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
+        _wrapper.escrowPayment(unsupportedAsset, escrowAmount);
+    }
+
+    function testEscrowPaymentQueryOnlyAsset() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.QUERY_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        uint248 escrowAmount = 1000e18;
+
+        vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);
+        _wrapper.escrowPayment(tokenAddress, escrowAmount);
+    }
+
+    function testEscrowPaymentZeroAmount() public {
+        MockERC20 mockToken = new MockERC20();
+        address tokenAddress = address(mockToken);
+        address priceFeed = address(new MockV3Aggregator(8, 1e8)); // 1 USD
+
+        _wrapper.setPaymentAsset(
+            tokenAddress,
+            AssetManagement.PaymentAsset({
+                allowedPaymentTypes: AssetManagement.SEND_PAYMENT_FLAG,
+                priceFeed: priceFeed,
+                tokenDecimals: 18,
+                stalePriceThresholdInSeconds: 100
+            })
+        );
+
+        mockToken.mint(address(this), 1000e18);
+        mockToken.approve(address(_wrapper), 1000e18);
+
+        (uint248 actualAmountReceived,) = _wrapper.escrowPayment(tokenAddress, 0);
+
+        assertEq(actualAmountReceived, 0);
     }
 }


### PR DESCRIPTION
Part of the effort to split #17 into smaller changes.

# Rationale for this change
enable the Asset Management library to pull payment and quote price in USD.

# What changes are included in this PR?
- add escrowPayment to AssetManagement lib
- refactor AssetManagement to include internal method _pullAndQoute as it's used in two methods

# Are these changes tested?
Yes
