### PR TITLE
feat: `EscrowPayment` library

### DIFF
--- a/src/libraries/EscrowPayment.sol
+++ b/src/libraries/EscrowPayment.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @title EscrowPayment
+library EscrowPayment {
+    /// @notice Transaction struct
+    /// @dev The transaction struct is not meant to be stored
+    // solhint-disable-next-line gas-struct-packing
+    struct Transaction {
+        /// @notice The asset being transferred
+        address asset;
+        /// @notice The amount of the source asset
+        uint248 amount;
+        /// @notice The address of the sender
+        address from;
+        /// @notice The address of the receiver
+        address to;
+    }
+
+    struct EscrowPaymentStorage {
+        /// @notice Global nonce for the escrow payment
+        uint248 nonce;
+        /// @notice Mapping of transaction hashes to their nonces, if nonce is 0, the transaction is not authorized
+        mapping(bytes32 transactionHash => uint248 transactionNonce) transactionNonces;
+    }
+
+    /// @notice Increments the global nonce for the escrow payment
+    /// @param escrowPaymentStorage The storage of the escrow payment
+    modifier incrementNonce(EscrowPaymentStorage storage escrowPaymentStorage) {
+        ++escrowPaymentStorage.nonce;
+        _;
+    }
+
+    /// @notice Generates the transaction hash
+    /// @param nonce Nonce of the transaction
+    /// @param transaction The transaction to generate the hash for
+    /// @return transactionHash The hash of the transaction
+    function generateTransactionHash(Transaction memory transaction, uint248 nonce) internal view returns (bytes32) {
+        return keccak256(abi.encode(transaction, nonce, block.chainid));
+    }
+
+    /// @notice Authorizes a transaction
+    /// @param escrowPaymentStorage The storage of the escrow payment
+    /// @param transaction The transaction to authorize
+    /// @return transactionHash The hash of the transaction
+    function authorize(EscrowPaymentStorage storage escrowPaymentStorage, Transaction memory transaction)
+        internal
+        incrementNonce(escrowPaymentStorage)
+        returns (bytes32 transactionHash)
+    {
+        transactionHash = generateTransactionHash(transaction, escrowPaymentStorage.nonce);
+        escrowPaymentStorage.transactionNonces[transactionHash] = escrowPaymentStorage.nonce;
+    }
+}

--- a/test/libraries/EscrowPayment.t.sol
+++ b/test/libraries/EscrowPayment.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {EscrowPayment} from "../../src/libraries/EscrowPayment.sol";
+
+contract EscrowPaymentWrapper {
+    EscrowPayment.EscrowPaymentStorage internal _escrowPaymentStorage;
+
+    function authorize(EscrowPayment.Transaction calldata transaction) external {
+        EscrowPayment.authorize(_escrowPaymentStorage, transaction);
+    }
+
+    function getNonce() external view returns (uint248) {
+        return _escrowPaymentStorage.nonce;
+    }
+
+    function getTransactionNonce(bytes32 transactionHash) external view returns (uint248) {
+        return _escrowPaymentStorage.transactionNonces[transactionHash];
+    }
+
+    function generateTransactionHash(EscrowPayment.Transaction calldata transaction, uint248 nonce)
+        external
+        view
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(transaction, nonce, block.chainid));
+    }
+
+    function setNonce(uint248 nonce) external {
+        _escrowPaymentStorage.nonce = nonce;
+    }
+}
+
+contract EscrowPaymentTest is Test {
+    EscrowPaymentWrapper internal _wrapper;
+    EscrowPayment.Transaction internal _sampleTransaction;
+
+    function setUp() public {
+        _wrapper = new EscrowPaymentWrapper();
+
+        _sampleTransaction = EscrowPayment.Transaction({
+            asset: address(0x1234),
+            amount: 1000,
+            from: address(0x5678),
+            to: address(0x9abc)
+        });
+    }
+
+    function testInitialState() public view {
+        assertEq(_wrapper.getNonce(), 0);
+    }
+
+    function testAuthorizeBasic() public {
+        uint248 expectedNonce = 1;
+        bytes32 expectedHash = _wrapper.generateTransactionHash(_sampleTransaction, expectedNonce);
+
+        _wrapper.authorize(_sampleTransaction);
+
+        assertEq(_wrapper.getNonce(), expectedNonce);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), expectedNonce);
+    }
+
+    function testAuthorizeIncrementsNonce() public {
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 1);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 2);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), 3);
+    }
+
+    function testAuthorizeMultipleTransactions() public {
+        EscrowPayment.Transaction memory transaction1 =
+            EscrowPayment.Transaction({asset: address(0x1111), amount: 100, from: address(0x2222), to: address(0x3333)});
+
+        EscrowPayment.Transaction memory transaction2 =
+            EscrowPayment.Transaction({asset: address(0x4444), amount: 200, from: address(0x5555), to: address(0x6666)});
+
+        bytes32 hash1 = _wrapper.generateTransactionHash(transaction1, 1);
+        bytes32 hash2 = _wrapper.generateTransactionHash(transaction2, 2);
+
+        _wrapper.authorize(transaction1);
+        _wrapper.authorize(transaction2);
+
+        assertEq(_wrapper.getNonce(), 2);
+        assertEq(_wrapper.getTransactionNonce(hash1), 1);
+        assertEq(_wrapper.getTransactionNonce(hash2), 2);
+    }
+
+    function testAuthorizeWithDifferentChainId() public {
+        uint256 originalChainId = block.chainid;
+
+        bytes32 hash1 = _wrapper.generateTransactionHash(_sampleTransaction, 1);
+        _wrapper.authorize(_sampleTransaction);
+
+        vm.chainId(999);
+
+        bytes32 hash2 = _wrapper.generateTransactionHash(_sampleTransaction, 2);
+        _wrapper.authorize(_sampleTransaction);
+
+        assertNotEq(hash1, hash2);
+        assertEq(_wrapper.getTransactionNonce(hash1), 1);
+        assertEq(_wrapper.getTransactionNonce(hash2), 2);
+
+        vm.chainId(originalChainId);
+    }
+
+    function testAuthorizeWithZeroValues() public {
+        EscrowPayment.Transaction memory zeroTransaction =
+            EscrowPayment.Transaction({asset: address(0), amount: 0, from: address(0), to: address(0)});
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(zeroTransaction, 1);
+
+        _wrapper.authorize(zeroTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+
+    function testAuthorizeWithMaxValues() public {
+        // solhint-disable-next-line gas-small-strings
+        EscrowPayment.Transaction memory maxTransaction = EscrowPayment.Transaction({
+            asset: address(type(uint160).max),
+            amount: type(uint248).max,
+            from: address(type(uint160).max),
+            to: address(type(uint160).max)
+        });
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(maxTransaction, 1);
+
+        _wrapper.authorize(maxTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+
+    function testTransactionHashUniqueness() public view {
+        bytes32 hash1 = _wrapper.generateTransactionHash(_sampleTransaction, 1);
+        bytes32 hash2 = _wrapper.generateTransactionHash(_sampleTransaction, 2);
+
+        assertNotEq(hash1, hash2);
+
+        EscrowPayment.Transaction memory differentTransaction = EscrowPayment.Transaction({
+            asset: address(0x1234),
+            amount: 2000,
+            from: address(0x5678),
+            to: address(0x9abc)
+        });
+
+        bytes32 hash3 = _wrapper.generateTransactionHash(differentTransaction, 1);
+        assertNotEq(hash1, hash3);
+    }
+
+    function testNonceOverflow() public {
+        _wrapper.setNonce(type(uint248).max - 1);
+
+        _wrapper.authorize(_sampleTransaction);
+        assertEq(_wrapper.getNonce(), type(uint248).max);
+
+        vm.expectRevert();
+        _wrapper.authorize(_sampleTransaction);
+    }
+
+    function testFuzzAuthorize(address asset, uint248 amount, address from, address to) public {
+        EscrowPayment.Transaction memory fuzzTransaction =
+            EscrowPayment.Transaction({asset: asset, amount: amount, from: from, to: to});
+
+        bytes32 expectedHash = _wrapper.generateTransactionHash(fuzzTransaction, 1);
+
+        _wrapper.authorize(fuzzTransaction);
+
+        assertEq(_wrapper.getNonce(), 1);
+        assertEq(_wrapper.getTransactionNonce(expectedHash), 1);
+    }
+}


### PR DESCRIPTION
Part of the effort to split #17 into smaller changes.

# What changes are included in this PR?
- add new lib called `EscrowPayment` which is responsible into hashing escrowed transactions 

# Are these changes tested?
Yes
