### PR TITLE
feat: integrate public authorize methods

### DIFF
--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -107,7 +107,7 @@ interface IZKPay {
         bytes calldata callbackData
     ) external;
 
-    /// @notice Authorizes a payment to a target address
+    /// @notice Authorizes a payment to a target merchant
     /// the payment will be pulled from `msg.sender` and held in ZKpay contract as escrow
     /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
     /// @param asset The address of the ERC20 token to send
@@ -116,7 +116,6 @@ interface IZKPay {
     /// @param merchant The merchant address
     /// @param memo Additional data or information about the payment
     /// @param itemId The item ID
-    /// @return transactionHash The hash of the transaction
     function authorize(
         address asset,
         uint248 amount,
@@ -124,7 +123,27 @@ interface IZKPay {
         address merchant,
         bytes calldata memo,
         bytes32 itemId
-    ) external returns (bytes32 transactionHash);
+    ) external;
+
+    /// @notice Authorizes a payment to a target merchant with a callback contract
+    /// the payment will be pulled from `msg.sender` and held in ZKpay contract as escrow
+    /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
+    /// @param asset The address of the ERC20 token to send
+    /// @param amount The amount of tokens to send
+    /// @param onBehalfOf The identifier on whose behalf the payment is made
+    /// @param merchant The merchant address
+    /// @param memo Additional data or information about the payment
+    /// @param callbackContractAddress The address of the callback contract
+    /// @param callbackData The data to send to the callback contract
+    function authorizeWithCallback(
+        address asset,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address merchant,
+        bytes calldata memo,
+        address callbackContractAddress,
+        bytes calldata callbackData
+    ) external;
 
     /// @notice Sets the merchant configuration for the caller
     /// @param config Merchant configuration struct

--- a/test/module/PaymentLogic.t.sol
+++ b/test/module/PaymentLogic.t.sol
@@ -357,7 +357,7 @@ contract PaymentLogicAuthorizePaymentWrapper {
 
     function authorizePayment(PaymentLogic.AuthorizePaymentParams calldata params)
         external
-        returns (bytes32 transactionHash)
+        returns (EscrowPayment.Transaction memory transaction, bytes32 transactionHash)
     {
         return PaymentLogic.authorizePayment(zkPayStorage, params);
     }
@@ -406,7 +406,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         PaymentLogic.AuthorizePaymentParams memory params =
             PaymentLogic.AuthorizePaymentParams({asset: SXT, amount: amount, merchant: MERCHANT, itemId: itemId});
 
-        bytes32 txHash = wrapper.authorizePayment(params);
+        (, bytes32 txHash) = wrapper.authorizePayment(params);
 
         assertTrue(wrapper.isTransactionAuthorized(txHash));
         assertEq(IERC20(SXT).balanceOf(address(wrapper)), amount);
@@ -426,7 +426,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         PaymentLogic.AuthorizePaymentParams memory params =
             PaymentLogic.AuthorizePaymentParams({asset: SXT, amount: amount, merchant: MERCHANT, itemId: itemId});
 
-        bytes32 txHash = wrapper.authorizePayment(params);
+        (, bytes32 txHash) = wrapper.authorizePayment(params);
 
         assertTrue(wrapper.isTransactionAuthorized(txHash));
         assertEq(IERC20(SXT).balanceOf(address(wrapper)), amount);
@@ -502,7 +502,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         PaymentLogic.AuthorizePaymentParams memory params =
             PaymentLogic.AuthorizePaymentParams({asset: SXT, amount: amount, merchant: MERCHANT, itemId: itemId});
 
-        bytes32 txHash = wrapper.authorizePayment(params);
+        (, bytes32 txHash) = wrapper.authorizePayment(params);
 
         assertTrue(wrapper.isTransactionAuthorized(txHash));
         assertEq(IERC20(SXT).balanceOf(address(wrapper)), amount);
@@ -526,8 +526,8 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         PaymentLogic.AuthorizePaymentParams memory params2 =
             PaymentLogic.AuthorizePaymentParams({asset: SXT, amount: amount2, merchant: MERCHANT, itemId: itemId2});
 
-        bytes32 txHash1 = wrapper.authorizePayment(params1);
-        bytes32 txHash2 = wrapper.authorizePayment(params2);
+        (, bytes32 txHash1) = wrapper.authorizePayment(params1);
+        (, bytes32 txHash2) = wrapper.authorizePayment(params2);
 
         assertTrue(wrapper.isTransactionAuthorized(txHash1));
         assertTrue(wrapper.isTransactionAuthorized(txHash2));
@@ -554,7 +554,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         uint248 amountInUSD = amount * 10;
 
         if (amountInUSD >= itemPrice) {
-            bytes32 txHash = wrapper.authorizePayment(params);
+            (, bytes32 txHash) = wrapper.authorizePayment(params);
             assertTrue(wrapper.isTransactionAuthorized(txHash));
             assertEq(IERC20(SXT).balanceOf(address(wrapper)), amount);
         } else {
@@ -576,7 +576,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         PaymentLogic.AuthorizePaymentParams memory params =
             PaymentLogic.AuthorizePaymentParams({asset: SXT, amount: amount, merchant: merchant, itemId: itemId});
 
-        bytes32 txHash = wrapper.authorizePayment(params);
+        (, bytes32 txHash) = wrapper.authorizePayment(params);
         assertTrue(wrapper.isTransactionAuthorized(txHash));
         assertEq(IERC20(SXT).balanceOf(address(wrapper)), amount);
         vm.stopPrank();
@@ -591,7 +591,7 @@ contract PaymentLogicAuthorizePaymentTest is Test {
         vm.startPrank(USER);
         IERC20(SXT).approve(address(wrapper), amount);
 
-        bytes32 txHash = wrapper.authorizePayment(
+        (, bytes32 txHash) = wrapper.authorizePayment(
             PaymentLogic.AuthorizePaymentParams({
                 asset: SXT,
                 amount: amount,


### PR DESCRIPTION
# Rationale for this change
Add public facing `authorizeWithCallback` method.

# What changes are included in this PR?
- updated `authorized` method to use internal method.
- updated paymentLogic to return tx and txHash. 
- added  public facing `authorizeWithCallback` method.

# Are these changes tested?
Yes
