### PR TITLE
feat: send path override

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,7 @@ extra_output = ["storageLayout"]
 fs_permissions = [{ access = "read-write", path = "./" }]
 optimizer = true
 optimizer_runs = 2000
+
 # Only show coverage for files that do not match the specified regex pattern.
 no_match_coverage = "test/mocks/**|script/**"
 

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -111,6 +111,22 @@ interface IZKPay {
         bytes32 itemId
     ) external;
 
+    /// @notice Allows for sending ERC20 tokens with a custom swap path override
+    /// @param customSourceAssetPath The custom swap path to override the stored sourceAssetPaths mapping
+    /// @param amount The amount of tokens to send
+    /// @param onBehalfOf The identifier on whose behalf the payment is made
+    /// @param merchant The merchant address
+    /// @param memo Additional data or information about the payment
+    /// @param itemId The item ID
+    function sendPathOverride(
+        bytes calldata customSourceAssetPath,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address merchant,
+        bytes calldata memo,
+        bytes32 itemId
+    ) external;
+
     /// @notice Allows for sending ERC20 tokens to a target address with a callback contract
     /// @param asset The address of the ERC20 token to send
     /// @param amount The amount of tokens to send

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -127,6 +127,24 @@ interface IZKPay {
         bytes32 itemId
     ) external;
 
+    /// @notice Allows for sending ERC20 tokens with a custom swap path override and a callback contract
+    /// @param customSourceAssetPath The custom swap path to override the stored sourceAssetPaths mapping
+    /// @param amount The amount of tokens to send
+    /// @param onBehalfOf The identifier on whose behalf the payment is made
+    /// @param merchant The merchant address
+    /// @param memo Additional data or information about the payment
+    /// @param callbackContractAddress The address of the callback contract
+    /// @param callbackData The data to send to the callback contract
+    function sendWithCallbackPathOverride(
+        bytes calldata customSourceAssetPath,
+        uint248 amount,
+        bytes32 onBehalfOf,
+        address merchant,
+        bytes calldata memo,
+        address callbackContractAddress,
+        bytes calldata callbackData
+    ) external;
+
     /// @notice Allows for sending ERC20 tokens to a target address with a callback contract
     /// @param asset The address of the ERC20 token to send
     /// @param amount The amount of tokens to send

--- a/src/libraries/SwapLogic.sol
+++ b/src/libraries/SwapLogic.sol
@@ -245,12 +245,20 @@ library SwapLogic {
         address sourceAsset,
         address merchant,
         uint256 sourceAssetAmountIn,
-        address targetAssetRecipient
+        address targetAssetRecipient,
+        bytes memory customSourceAssetPath
     ) internal returns (uint256 receivedTargetAssetAmount) {
-        bytes memory swapPath = _connect2Paths(
-            _swapLogicStorage.assetSwapPaths.sourceAssetPaths[sourceAsset],
-            _swapLogicStorage.assetSwapPaths.merchantTargetAssetPaths[merchant]
-        );
+        bytes memory swapPath;
+        if (customSourceAssetPath.length > 0) {
+            swapPath = _connect2Paths(
+                customSourceAssetPath, _swapLogicStorage.assetSwapPaths.merchantTargetAssetPaths[merchant]
+            );
+        } else {
+            swapPath = _connect2Paths(
+                _swapLogicStorage.assetSwapPaths.sourceAssetPaths[sourceAsset],
+                _swapLogicStorage.assetSwapPaths.merchantTargetAssetPaths[merchant]
+            );
+        }
 
         receivedTargetAssetAmount = _swapExactAmountIn(
             _swapLogicStorage.swapLogicConfig.router, swapPath, sourceAssetAmountIn, targetAssetRecipient

--- a/src/module/PaymentLogic.sol
+++ b/src/module/PaymentLogic.sol
@@ -74,6 +74,7 @@ library PaymentLogic {
         uint248 amount;
         address merchant;
         bytes32 itemId;
+        bytes customSourceAssetPath;
     }
 
     struct ProcessPaymentResult {
@@ -104,7 +105,11 @@ library PaymentLogic {
         if (receivedTransferAmount > 0) {
             MerchantLogic.MerchantConfig memory merchantConfig = _zkPayStorage.merchantConfigs[params.merchant];
             result.recievedPayoutAmount = _zkPayStorage.swapLogicStorage.swapExactSourceAssetAmount(
-                params.asset, params.merchant, receivedTransferAmount, merchantConfig.payoutAddress
+                params.asset,
+                params.merchant,
+                receivedTransferAmount,
+                merchantConfig.payoutAddress,
+                params.customSourceAssetPath
             );
         }
 
@@ -237,7 +242,7 @@ library PaymentLogic {
         // slither-disable-next-line reentrancy-events
         MerchantLogic.MerchantConfig memory merchantConfig = _zkPayStorage.merchantConfigs[params.merchant];
         result.receivedTargetAssetAmount = _zkPayStorage.swapLogicStorage.swapExactSourceAssetAmount(
-            params.sourceAsset, params.merchant, toBePaidInSourceToken, merchantConfig.payoutAddress
+            params.sourceAsset, params.merchant, toBePaidInSourceToken, merchantConfig.payoutAddress, ""
         );
 
         // 2. refund client

--- a/test/libraries/SwapLogic.t.sol
+++ b/test/libraries/SwapLogic.t.sol
@@ -314,7 +314,7 @@ contract SwapLogicWrapper {
         address targetAssetRecipient
     ) external returns (uint256 receivedTargetAssetAmount) {
         return SwapLogic.swapExactSourceAssetAmount(
-            _swapLogicStorage, sourceAsset, merchant, sourceAssetAmountIn, targetAssetRecipient
+            _swapLogicStorage, sourceAsset, merchant, sourceAssetAmountIn, targetAssetRecipient, ""
         );
     }
 }

--- a/test/module/PaymentLogic.t.sol
+++ b/test/module/PaymentLogic.t.sol
@@ -275,8 +275,13 @@ contract PaymentLogicProcessPaymentTest is Test {
         deal(SXT, address(this), amount);
         IERC20(SXT).approve(address(wrapper), amount);
 
-        PaymentLogic.ProcessPaymentParams memory params =
-            PaymentLogic.ProcessPaymentParams({asset: SXT, amount: amount, merchant: MERCHANT, itemId: itemId});
+        PaymentLogic.ProcessPaymentParams memory params = PaymentLogic.ProcessPaymentParams({
+            asset: SXT,
+            amount: amount,
+            merchant: MERCHANT,
+            itemId: itemId,
+            customSourceAssetPath: ""
+        });
 
         try wrapper.processPayment(params) returns (PaymentLogic.ProcessPaymentResult memory result) {
             assertEq(result.payoutToken, USDC);
@@ -302,8 +307,13 @@ contract PaymentLogicProcessPaymentTest is Test {
         deal(SXT, address(this), amount);
         IERC20(SXT).approve(address(wrapper), amount);
 
-        PaymentLogic.ProcessPaymentParams memory params =
-            PaymentLogic.ProcessPaymentParams({asset: SXT, amount: amount, merchant: MERCHANT, itemId: itemId});
+        PaymentLogic.ProcessPaymentParams memory params = PaymentLogic.ProcessPaymentParams({
+            asset: SXT,
+            amount: amount,
+            merchant: MERCHANT,
+            itemId: itemId,
+            customSourceAssetPath: ""
+        });
 
         vm.expectRevert(PaymentLogic.InsufficientPayment.selector);
         wrapper.processPayment(params);
@@ -318,7 +328,8 @@ contract PaymentLogicProcessPaymentTest is Test {
             asset: unsupportedAsset,
             amount: amount,
             merchant: MERCHANT,
-            itemId: itemId
+            itemId: itemId,
+            customSourceAssetPath: ""
         });
 
         vm.expectRevert(AssetManagement.AssetIsNotSupportedForThisMethod.selector);


### PR DESCRIPTION
# Rationale for this change?
Enable client to provide their preferred path from source asset to USDT.

# What changes are included in this PR?
- added sendWithCallbackPathOverride method
- added sendPathOverride method

# Are these changes tested?
Yes