### PR TITLE
feat: include payment metadata to callback  by itemId merchant config…

### DIFF
--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -257,13 +257,15 @@ contract ZKPay is IZKPay, Initializable, OwnableUpgradeable, ReentrancyGuardUpgr
         if (callbackConfig.includePaymentMetadata) {
             PaymentMetadata memory metadata = PaymentMetadata({
                 payoutToken: result.payoutToken,
-                payoutAmount: result.recievedPayoutAmount,
+                payoutAmount: result.receivedPayoutAmount,
                 amountInUSD: result.amountInUSD,
                 onBehalfOf: params.onBehalfOf,
                 sender: msg.sender,
                 itemId: params.itemId
             });
-            fullCallbackData = abi.encodePacked(callbackConfig.funcSig, params.callbackData, abi.encode(metadata));
+
+            // slither-disable-next-line encode-packed-collision
+            fullCallbackData = abi.encodePacked(callbackConfig.funcSig, abi.encode(metadata), params.callbackData);
         } else {
             fullCallbackData = abi.encodePacked(callbackConfig.funcSig, params.callbackData);
         }

--- a/src/libraries/MerchantLogic.sol
+++ b/src/libraries/MerchantLogic.sol
@@ -34,8 +34,9 @@ library MerchantLogic {
     }
 
     struct ItemIdCallbackConfig {
-        address contractAddress;
         bytes4 funcSig;
+        address contractAddress;
+        bool includePaymentMetadata;
     }
 
     function setConfig(

--- a/src/module/PaymentLogic.sol
+++ b/src/module/PaymentLogic.sol
@@ -81,7 +81,7 @@ library PaymentLogic {
         address payoutToken;
         uint248 receivedProtocolFeeAmount;
         uint248 amountInUSD;
-        uint256 recievedPayoutAmount;
+        uint256 receivedPayoutAmount;
     }
 
     /// @notice Processes a direct payment with asset swapping to merchant's preferred payout token
@@ -105,7 +105,7 @@ library PaymentLogic {
         if (receivedTransferAmount > 0) {
             MerchantLogic.MerchantConfig memory merchantConfig =
                 _zkPayStorage.merchantLogicStorage.merchantConfigs[params.merchant];
-            result.recievedPayoutAmount = _zkPayStorage.swapLogicStorage.swapExactSourceAssetAmount(
+            result.receivedPayoutAmount = _zkPayStorage.swapLogicStorage.swapExactSourceAssetAmount(
                 params.asset,
                 params.merchant,
                 receivedTransferAmount,

--- a/test/PaymentFunctions.t.sol
+++ b/test/PaymentFunctions.t.sol
@@ -39,7 +39,7 @@ contract MockCallbackContract is IMerchantCallback {
         lastCallData = abi.encode(value);
     }
 
-    function processCallbackWithMetadata(uint256 value, ZKPay.PaymentMetadata calldata metadata) external {
+    function processCallbackWithMetadata(ZKPay.PaymentMetadata calldata metadata, uint256 value) external {
         ++callCount;
         lastCallData = abi.encode(value);
         lastPaymentMetadata = metadata;

--- a/test/PaymentFunctions.t.sol
+++ b/test/PaymentFunctions.t.sol
@@ -21,6 +21,8 @@ contract MockCallbackContract is IMerchantCallback {
     address private _merchant;
     uint256 public callCount;
     bytes public lastCallData;
+    ZKPay.PaymentMetadata public lastPaymentMetadata;
+    bool public receivedMetadata;
 
     error CallbackFailed();
 
@@ -35,6 +37,17 @@ contract MockCallbackContract is IMerchantCallback {
     function processCallback(uint256 value) external {
         ++callCount;
         lastCallData = abi.encode(value);
+    }
+
+    function processCallbackWithMetadata(uint256 value, ZKPay.PaymentMetadata calldata metadata) external {
+        ++callCount;
+        lastCallData = abi.encode(value);
+        lastPaymentMetadata = metadata;
+        receivedMetadata = true;
+    }
+
+    function getLastPaymentMetadata() external view returns (ZKPay.PaymentMetadata memory) {
+        return lastPaymentMetadata;
     }
 
     function failingCallback() external pure {
@@ -81,7 +94,11 @@ contract PaymentFunctionsTest is Test {
         vm.prank(targetMerchant);
         zkpay.setItemIdCallbackConfig(
             bytes32(uint256(itemId)),
-            MerchantLogic.ItemIdCallbackConfig({contractAddress: contractAddress, funcSig: funcSig})
+            MerchantLogic.ItemIdCallbackConfig({
+                contractAddress: contractAddress,
+                funcSig: funcSig,
+                includePaymentMetadata: false
+            })
         );
     }
 
@@ -265,7 +282,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -329,7 +347,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(invalidCallbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -365,7 +384,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -415,7 +435,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -449,7 +470,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -481,7 +503,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -599,7 +622,8 @@ contract PaymentFunctionsTest is Test {
             bytes32(uint256(itemId)),
             MerchantLogic.ItemIdCallbackConfig({
                 contractAddress: address(callbackContract),
-                funcSig: MockCallbackContract.processCallback.selector
+                funcSig: MockCallbackContract.processCallback.selector,
+                includePaymentMetadata: false
             })
         );
 
@@ -613,5 +637,86 @@ contract PaymentFunctionsTest is Test {
         uint248 protocolFeeAmount = uint248((uint256(usdcAmount) * PROTOCOL_FEE) / PROTOCOL_FEE_PRECISION);
         assertEq(IERC20(USDC).balanceOf(treasury), protocolFeeAmount);
         assertGt(IERC20(USDC).balanceOf(targetMerchant), 0);
+    }
+
+    function testSendWithCallbackWithPaymentMetadata() public {
+        MockCallbackContract callbackContract = new MockCallbackContract(targetMerchant);
+        bytes memory callbackData = abi.encode(999);
+        bytes32 onBehalfOfBytes32 = _getOnBehalfOfBytes32();
+
+        vm.prank(targetMerchant);
+        zkpay.setMerchantConfig(
+            MerchantLogic.MerchantConfig({payoutToken: USDC, payoutAddress: targetMerchant, fulfillerPercentage: 0}),
+            DummyData.getDestinationAssetPath(USDC)
+        );
+
+        vm.prank(targetMerchant);
+        zkpay.setItemIdCallbackConfig(
+            bytes32(uint256(itemId)),
+            MerchantLogic.ItemIdCallbackConfig({
+                contractAddress: address(callbackContract),
+                funcSig: MockCallbackContract.processCallbackWithMetadata.selector,
+                includePaymentMetadata: true
+            })
+        );
+
+        IERC20(USDC).approve(address(zkpay), usdcAmount);
+
+        zkpay.sendWithCallback(
+            USDC, usdcAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(uint256(itemId)), callbackData
+        );
+
+        assertEq(callbackContract.callCount(), 1);
+        assertEq(abi.decode(callbackContract.lastCallData(), (uint256)), 999);
+        assertTrue(callbackContract.receivedMetadata());
+
+        ZKPay.PaymentMetadata memory metadata = callbackContract.getLastPaymentMetadata();
+        assertEq(metadata.payoutToken, USDC);
+        assertGt(metadata.payoutAmount, 0);
+        assertGt(metadata.amountInUSD, 0);
+        assertEq(metadata.onBehalfOf, onBehalfOfBytes32);
+        assertEq(metadata.sender, address(this));
+        assertEq(metadata.itemId, bytes32(uint256(itemId)));
+    }
+
+    function testSendWithCallbackPathOverrideWithPaymentMetadata() public {
+        MockCallbackContract callbackContract = new MockCallbackContract(targetMerchant);
+        bytes memory callbackData = abi.encode(777);
+        bytes32 onBehalfOfBytes32 = _getOnBehalfOfBytes32();
+        bytes memory customPath = DummyData.getOriginAssetPath(USDC);
+
+        vm.prank(targetMerchant);
+        zkpay.setMerchantConfig(
+            MerchantLogic.MerchantConfig({payoutToken: USDC, payoutAddress: targetMerchant, fulfillerPercentage: 0}),
+            DummyData.getDestinationAssetPath(USDC)
+        );
+
+        vm.prank(targetMerchant);
+        zkpay.setItemIdCallbackConfig(
+            bytes32(uint256(itemId)),
+            MerchantLogic.ItemIdCallbackConfig({
+                contractAddress: address(callbackContract),
+                funcSig: MockCallbackContract.processCallbackWithMetadata.selector,
+                includePaymentMetadata: true
+            })
+        );
+
+        IERC20(USDC).approve(address(zkpay), usdcAmount);
+
+        zkpay.sendWithCallbackPathOverride(
+            customPath, usdcAmount, onBehalfOfBytes32, targetMerchant, memoBytes, bytes32(uint256(itemId)), callbackData
+        );
+
+        assertEq(callbackContract.callCount(), 1);
+        assertEq(abi.decode(callbackContract.lastCallData(), (uint256)), 777);
+        assertTrue(callbackContract.receivedMetadata());
+
+        ZKPay.PaymentMetadata memory metadata = callbackContract.getLastPaymentMetadata();
+        assertEq(metadata.payoutToken, USDC);
+        assertGt(metadata.payoutAmount, 0);
+        assertGt(metadata.amountInUSD, 0);
+        assertEq(metadata.onBehalfOf, onBehalfOfBytes32);
+        assertEq(metadata.sender, address(this));
+        assertEq(metadata.itemId, bytes32(uint256(itemId)));
     }
 }

--- a/test/ZKPayMerchantConfig.t.sol
+++ b/test/ZKPayMerchantConfig.t.sol
@@ -72,19 +72,26 @@ contract ZKPayMerchantConfigTest is Test {
 
     function testSetAndGetItemIdCallbackConfig() public {
         bytes32 itemId = bytes32(uint256(456));
-        MerchantLogic.ItemIdCallbackConfig memory config =
-            MerchantLogic.ItemIdCallbackConfig({contractAddress: address(2), funcSig: bytes4(0x87654321)});
+        MerchantLogic.ItemIdCallbackConfig memory config = MerchantLogic.ItemIdCallbackConfig({
+            contractAddress: address(2),
+            funcSig: bytes4(0x87654321),
+            includePaymentMetadata: false
+        });
 
         _zkpay.setItemIdCallbackConfig(itemId, config);
 
         MerchantLogic.ItemIdCallbackConfig memory result = _zkpay.getItemIdCallbackConfig(address(this), itemId);
         assertEq(result.contractAddress, config.contractAddress);
         assertEq(result.funcSig, config.funcSig);
+        assertEq(result.includePaymentMetadata, config.includePaymentMetadata);
     }
 
     function testSetItemIdCallbackConfigInvalidItemId() public {
-        MerchantLogic.ItemIdCallbackConfig memory config =
-            MerchantLogic.ItemIdCallbackConfig({contractAddress: address(2), funcSig: bytes4(0x87654321)});
+        MerchantLogic.ItemIdCallbackConfig memory config = MerchantLogic.ItemIdCallbackConfig({
+            contractAddress: address(2),
+            funcSig: bytes4(0x87654321),
+            includePaymentMetadata: false
+        });
 
         vm.expectRevert(ZKPay.InvalidItemId.selector);
         _zkpay.setItemIdCallbackConfig(bytes32(0), config);
@@ -92,8 +99,11 @@ contract ZKPayMerchantConfigTest is Test {
 
     function testSetItemIdCallbackConfigInvalidContract() public {
         bytes32 itemId = bytes32(uint256(456));
-        MerchantLogic.ItemIdCallbackConfig memory config =
-            MerchantLogic.ItemIdCallbackConfig({contractAddress: address(0), funcSig: bytes4(0x87654321)});
+        MerchantLogic.ItemIdCallbackConfig memory config = MerchantLogic.ItemIdCallbackConfig({
+            contractAddress: address(0),
+            funcSig: bytes4(0x87654321),
+            includePaymentMetadata: false
+        });
 
         vm.expectRevert(ZKPay.InvalidCallbackContract.selector);
         _zkpay.setItemIdCallbackConfig(itemId, config);

--- a/test/libraries/MerchantLogic.t.sol
+++ b/test/libraries/MerchantLogic.t.sol
@@ -79,13 +79,17 @@ contract MerchantLogicTest is Test {
     function testSetAndGetItemIdCallback() public {
         address merchant = address(this);
         bytes32 itemId = bytes32(uint256(123));
-        MerchantLogic.ItemIdCallbackConfig memory callbackConfig =
-            MerchantLogic.ItemIdCallbackConfig({contractAddress: address(1), funcSig: bytes4(0x12345678)});
+        MerchantLogic.ItemIdCallbackConfig memory callbackConfig = MerchantLogic.ItemIdCallbackConfig({
+            contractAddress: address(1),
+            funcSig: bytes4(0x12345678),
+            includePaymentMetadata: false
+        });
 
         _wrapper.setItemIdCallback(merchant, itemId, callbackConfig);
 
         MerchantLogic.ItemIdCallbackConfig memory result = _wrapper.getItemIdCallback(merchant, itemId);
         assertEq(result.contractAddress, callbackConfig.contractAddress);
         assertEq(result.funcSig, callbackConfig.funcSig);
+        assertEq(result.includePaymentMetadata, callbackConfig.includePaymentMetadata);
     }
 }

--- a/test/module/PaymentLogic.t.sol
+++ b/test/module/PaymentLogic.t.sol
@@ -287,8 +287,8 @@ contract PaymentLogicProcessPaymentTest is Test {
             assertEq(result.payoutToken, USDC);
             assertEq(result.receivedProtocolFeeAmount, 0);
             assertGt(result.amountInUSD, 0);
-            assertGt(result.recievedPayoutAmount, 0);
-            assertEq(IERC20(USDC).balanceOf(wrapper.MERCHANT_PAYOUT_ADDRESS()), result.recievedPayoutAmount);
+            assertGt(result.receivedPayoutAmount, 0);
+            assertEq(IERC20(USDC).balanceOf(wrapper.MERCHANT_PAYOUT_ADDRESS()), result.receivedPayoutAmount);
         } catch (bytes memory reason) {
             emit log("Failed with reason:");
             emit log_bytes(reason);


### PR DESCRIPTION
# Rationale for this change
Give the option for merchant to receive payment metadata to callback method. 

# What changes are included in this PR?
- add bool includePaymentMetadata to ItemIdCallbackConfig
- add PaymentMetadata struct 
- encode and include PaymentMetadata as part of the executor callback 

# Are these changes tested?
Yes