### PR TITLE
refactor: rename ZKPay to DSPay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Space and Time | ZKPay Smart Contracts
+# Space and Time | DSPay Smart Contracts
 
 ## Git Hooks
 

--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -7,13 +7,13 @@ pragma solidity 0.8.28;
 import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 
-import {ZKPay} from "../src/ZKPay.sol";
+import {DSPay} from "../src/DSPay.sol";
 import {AssetManagement} from "../src/libraries/AssetManagement.sol";
 import {SwapLogic} from "../src/libraries/SwapLogic.sol";
 
 /// @title Deploy
-/// @notice Deploy the ZKPay contract
-/// @dev This script is used to deploy the ZKPay contract
+/// @notice Deploy the DSPay contract
+/// @dev This script is used to deploy the DSPay contract
 /// @dev It also sets the USDC payment asset
 contract Deploy is Script {
     using stdJson for string;
@@ -24,7 +24,7 @@ contract Deploy is Script {
         uint8 usdcTokenDecimals;
         uint64 usdcTokenStalePriceThresholdInSeconds;
         // Remaining slots: addresses (each takes a full slot)
-        address zkpayAdmin;
+        address dspayAdmin;
         address usdcTokenAddress;
         address usdcTokenPriceFeed;
         address router;
@@ -40,11 +40,11 @@ contract Deploy is Script {
         // Deploy contracts
         vm.startBroadcast();
 
-        // Deploy ZKPay
-        ZKPay zkpay =
-            new ZKPay(config.zkpayAdmin, SwapLogic.SwapLogicConfig({router: config.router, usdt: config.usdt}));
+        // Deploy DSPay
+        DSPay dspay =
+            new DSPay(config.dspayAdmin, SwapLogic.SwapLogicConfig({router: config.router, usdt: config.usdt}));
 
-        console.log("ZKPay deployed at:", address(zkpay));
+        console.log("DSPay deployed at:", address(dspay));
 
         // Set USDC payment asset
         AssetManagement.PaymentAsset memory usdcPaymentAsset = AssetManagement.PaymentAsset({
@@ -52,12 +52,12 @@ contract Deploy is Script {
             tokenDecimals: config.usdcTokenDecimals,
             stalePriceThresholdInSeconds: config.usdcTokenStalePriceThresholdInSeconds
         });
-        zkpay.setPaymentAsset(config.usdcTokenAddress, usdcPaymentAsset, config.usdcToUsdtPath);
+        dspay.setPaymentAsset(config.usdcTokenAddress, usdcPaymentAsset, config.usdcToUsdtPath);
 
         vm.stopBroadcast();
 
         // Create output JSON with deployed contract addresses
-        string memory outputJson = _createFormattedOutputJson(address(zkpay), config);
+        string memory outputJson = _createFormattedOutputJson(address(dspay), config);
 
         // Write output to file
         string memory outputPath = string.concat(vm.projectRoot(), "/script/output/output.json");
@@ -71,8 +71,8 @@ contract Deploy is Script {
         string memory configPath = string.concat(vm.projectRoot(), "/script/config.json");
         string memory configJson = vm.readFile(configPath);
 
-        // zkpay section
-        config.zkpayAdmin = configJson.readAddress(".zkpayAdmin");
+        // dspay section
+        config.dspayAdmin = configJson.readAddress(".dspayAdmin");
 
         // usdc payment asset section
         config.usdcTokenAddress = configJson.readAddress(".usdcTokenAddress");
@@ -88,24 +88,24 @@ contract Deploy is Script {
     }
 
     /// @notice Create a formatted JSON output with deployed contract addresses and configuration
-    /// @param zkPayAddress Address of the deployed ZKPay contract
+    /// @param dsPayAddress Address of the deployed DSPay contract
     /// @param config The configuration used for deployment
     /// @return formattedJson The formatted JSON string containing deployment information
-    function _createFormattedOutputJson(address zkPayAddress, Config memory config)
+    function _createFormattedOutputJson(address dsPayAddress, Config memory config)
         internal
         pure
         returns (string memory formattedJson)
     {
         // Create the deployedContracts section
         string memory deployedContracts = string.concat(
-            "  \"deployedContracts\": {\n", "    \"ZKPay\": \"", _addressToString(zkPayAddress), "\"\n", "  }"
+            "  \"deployedContracts\": {\n", "    \"DSPay\": \"", _addressToString(dsPayAddress), "\"\n", "  }"
         );
 
         // Create the config section
         string memory configSection = string.concat(
             "  \"config\": {\n",
-            "    \"zkpayAdmin\": \"",
-            _addressToString(config.zkpayAdmin),
+            "    \"dspayAdmin\": \"",
+            _addressToString(config.dspayAdmin),
             "\",\n",
             "    \"usdcTokenAddress\": \"",
             _addressToString(config.usdcTokenAddress),

--- a/script/input/config.json
+++ b/script/input/config.json
@@ -1,5 +1,5 @@
 {
-  "zkpayAdmin": "0xd341DF0d9335e55a095912f7f76Ed5289e64e4C6",
+  "dspayAdmin": "0xd341DF0d9335e55a095912f7f76Ed5289e64e4C6",
   "posqlMerchantAddress": "0xd341DF0d9335e55a095912f7f76Ed5289e64e4C6",
   "Usdc payment asset Section": "----------------------------------",
   "usdcTokenAddress": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238",

--- a/src/interfaces/IDSPay.sol
+++ b/src/interfaces/IDSPay.sol
@@ -5,7 +5,7 @@ import {AssetManagement} from "../libraries/AssetManagement.sol";
 import {MerchantLogic} from "../libraries/MerchantLogic.sol";
 import {EscrowPayment} from "../libraries/EscrowPayment.sol";
 
-interface IZKPay {
+interface IDSPay {
     /// @notice Emitted when a payment is made
     /// @param asset The asset used for payment
     /// @param amount The amount of tokens used for payment
@@ -144,7 +144,7 @@ interface IZKPay {
     ) external;
 
     /// @notice Authorizes a payment to a target merchant
-    /// the payment will be pulled from `msg.sender` and held in ZKpay contract as escrow
+    /// the payment will be pulled from `msg.sender` and held in DSpay contract as escrow
     /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
     /// @param asset The address of the ERC20 token to send
     /// @param amount The amount of tokens to send
@@ -162,7 +162,7 @@ interface IZKPay {
     ) external;
 
     /// @notice Authorizes a payment to a target merchant with a callback contract
-    /// the payment will be pulled from `msg.sender` and held in ZKpay contract as escrow
+    /// the payment will be pulled from `msg.sender` and held in DSpay contract as escrow
     /// the payment is accounted for `onBehalfOf` which means that any refunded amount will be send to `onBehalfOf`
     /// @param asset The address of the ERC20 token to send
     /// @param amount The amount of tokens to send

--- a/src/libraries/AssetManagement.sol
+++ b/src/libraries/AssetManagement.sol
@@ -40,7 +40,7 @@ library AssetManagement {
     event AssetRemoved(address asset);
 
     /**
-     * @notice Defines payment asset configuration within the ZKpay protocol.
+     * @notice Defines payment asset configuration within the DSpay protocol.
      */
     struct PaymentAsset {
         /// @notice  Price oracle

--- a/test/DSPayMerchantConfig.t.sol
+++ b/test/DSPayMerchantConfig.t.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {MockV3Aggregator} from "@chainlink/contracts/src/v0.8/tests/MockV3Aggregator.sol";
 
-import {ZKPay} from "../src/ZKPay.sol";
+import {DSPay} from "../src/DSPay.sol";
 import {MerchantLogic} from "../src/libraries/MerchantLogic.sol";
 import {DummyData} from "./data/DummyData.sol";
 import {ZERO_ADDRESS} from "../src/libraries/Constants.sol";
 
-contract ZKPayMerchantConfigTest is Test {
-    ZKPay internal _zkpay;
+contract DSPayMerchantConfigTest is Test {
+    DSPay internal _dspay;
     address internal _admin;
     address internal _priceFeed;
     address internal _sxt;
@@ -21,7 +21,7 @@ contract ZKPayMerchantConfigTest is Test {
         _sxt = vm.addr(0x3);
 
         vm.prank(_admin);
-        _zkpay = new ZKPay(_admin, DummyData.getSwapLogicConfig());
+        _dspay = new DSPay(_admin, DummyData.getSwapLogicConfig());
     }
 
     function testSetAndGetMerchantConfig() public {
@@ -41,9 +41,9 @@ contract ZKPayMerchantConfigTest is Test {
         emit MerchantLogic.MerchantConfigSet(
             address(this), merchantConfig.payoutToken, merchantConfig.payoutAddresses, merchantConfig.payoutPercentages
         );
-        _zkpay.setMerchantConfig(merchantConfig, DummyData.getDestinationAssetPath(merchantConfig.payoutToken));
+        _dspay.setMerchantConfig(merchantConfig, DummyData.getDestinationAssetPath(merchantConfig.payoutToken));
 
-        MerchantLogic.MerchantConfig memory r = _zkpay.getMerchantConfig(address(this));
+        MerchantLogic.MerchantConfig memory r = _dspay.getMerchantConfig(address(this));
         assertEq(r.payoutToken, merchantConfig.payoutToken);
         assertEq(r.payoutAddresses.length, 2);
         assertEq(r.payoutAddresses[0], address(3));
@@ -64,7 +64,7 @@ contract ZKPayMerchantConfigTest is Test {
         });
 
         vm.expectRevert(MerchantLogic.PayoutAddressCannotBeZero.selector);
-        _zkpay.setMerchantConfig(merchantConfig, DummyData.getDestinationAssetPath(merchantConfig.payoutToken));
+        _dspay.setMerchantConfig(merchantConfig, DummyData.getDestinationAssetPath(merchantConfig.payoutToken));
     }
 
     function testSetAndGetItemIdCallbackConfig() public {
@@ -75,9 +75,9 @@ contract ZKPayMerchantConfigTest is Test {
             includePaymentMetadata: false
         });
 
-        _zkpay.setItemIdCallbackConfig(itemId, config);
+        _dspay.setItemIdCallbackConfig(itemId, config);
 
-        MerchantLogic.ItemIdCallbackConfig memory result = _zkpay.getItemIdCallbackConfig(address(this), itemId);
+        MerchantLogic.ItemIdCallbackConfig memory result = _dspay.getItemIdCallbackConfig(address(this), itemId);
         assertEq(result.contractAddress, config.contractAddress);
         assertEq(result.funcSig, config.funcSig);
         assertEq(result.includePaymentMetadata, config.includePaymentMetadata);
@@ -90,8 +90,8 @@ contract ZKPayMerchantConfigTest is Test {
             includePaymentMetadata: false
         });
 
-        vm.expectRevert(ZKPay.InvalidItemId.selector);
-        _zkpay.setItemIdCallbackConfig(bytes32(0), config);
+        vm.expectRevert(DSPay.InvalidItemId.selector);
+        _dspay.setItemIdCallbackConfig(bytes32(0), config);
     }
 
     function testSetItemIdCallbackConfigInvalidContract() public {
@@ -102,7 +102,7 @@ contract ZKPayMerchantConfigTest is Test {
             includePaymentMetadata: false
         });
 
-        vm.expectRevert(ZKPay.InvalidCallbackContract.selector);
-        _zkpay.setItemIdCallbackConfig(itemId, config);
+        vm.expectRevert(DSPay.InvalidCallbackContract.selector);
+        _dspay.setItemIdCallbackConfig(itemId, config);
     }
 }


### PR DESCRIPTION
# Rationale for this change

The contract should be named DSPay instead of ZKPay.

# What changes are included in this PR?

replace zk/ZK with ds/DS in files and filenames.

```
git grep -il zk -- . ':!CHANGELOG.md' ':!script/output/' ':!broadcast' | xargs sed -i 's/zk/ds/g;s/ZK/DS/g'; git ls-files | grep ZK | while read f; do git mv "$f" "$(echo $f | sed 's/ZK/DS/g')"; done
```

# Are these changes tested?
Yes, by existing tests