### PR TITLE
feat!: accept merchant as a parameter for getItemIdCallbackConfig

### DIFF
--- a/src/ZKPay.sol
+++ b/src/ZKPay.sol
@@ -407,11 +407,11 @@ contract ZKPay is IZKPay, Initializable, OwnableUpgradeable, ReentrancyGuardUpgr
         _zkPayStorage.merchantLogicStorage.setItemIdCallback(msg.sender, itemId, config);
     }
 
-    function getItemIdCallbackConfig(bytes32 itemId)
+    function getItemIdCallbackConfig(address merchant, bytes32 itemId)
         external
         view
         returns (MerchantLogic.ItemIdCallbackConfig memory config)
     {
-        return _zkPayStorage.merchantLogicStorage.getItemIdCallback(msg.sender, itemId);
+        return _zkPayStorage.merchantLogicStorage.getItemIdCallback(merchant, itemId);
     }
 }

--- a/src/interfaces/IZKPay.sol
+++ b/src/interfaces/IZKPay.sol
@@ -249,9 +249,10 @@ interface IZKPay {
     function setItemIdCallbackConfig(bytes32 itemId, MerchantLogic.ItemIdCallbackConfig calldata config) external;
 
     /// @notice Gets callback configuration for an item ID
+    /// @param merchant The merchant address
     /// @param itemId The item ID
     /// @return config The callback configuration
-    function getItemIdCallbackConfig(bytes32 itemId)
+    function getItemIdCallbackConfig(address merchant, bytes32 itemId)
         external
         view
         returns (MerchantLogic.ItemIdCallbackConfig memory config);

--- a/test/ZKPayMerchantConfig.t.sol
+++ b/test/ZKPayMerchantConfig.t.sol
@@ -77,7 +77,7 @@ contract ZKPayMerchantConfigTest is Test {
 
         _zkpay.setItemIdCallbackConfig(itemId, config);
 
-        MerchantLogic.ItemIdCallbackConfig memory result = _zkpay.getItemIdCallbackConfig(itemId);
+        MerchantLogic.ItemIdCallbackConfig memory result = _zkpay.getItemIdCallbackConfig(address(this), itemId);
         assertEq(result.contractAddress, config.contractAddress);
         assertEq(result.funcSig, config.funcSig);
     }


### PR DESCRIPTION
# Rationale for this change

One should be able to get the callback config for any merchant, not just oneself.

# What changes are included in this PR?

Added `merchant` as a parameter to `getItemIdCallbackConfig`.

# Are these changes tested?
Yes