### PR TITLE
refactor: delete unused functions and associated tests

### DIFF
--- a/src/libraries/AssetManagement.sol
+++ b/src/libraries/AssetManagement.sol
@@ -194,41 +194,6 @@ library AssetManagement {
         tokenAmount = (usdValue * uint248(10 ** _assets[asset].tokenDecimals)) / adjustedPrice;
     }
 
-    /// @dev Pulls `amount` of `asset` from msg.sender to `to`,
-    /// measures the real amount received (fee-on-transfer tokens),
-    /// and converts it to USD.
-    /// Reverts if the asset isn’t supported for the given payment type.
-    function _pullAndQuote(
-        mapping(address asset => PaymentAsset) storage _assets,
-        address asset,
-        address to,
-        uint248 amount
-    ) internal returns (uint248 actualAmountReceived, uint248 amountInUSD) {
-        if (!isSupported(_assets, asset)) {
-            revert AssetIsNotSupportedForThisMethod();
-        }
-
-        IERC20 token = IERC20(asset);
-        uint256 beforeBalance = token.balanceOf(to);
-        SafeERC20.safeTransferFrom(token, msg.sender, to, amount);
-        uint256 afterBalance = token.balanceOf(to);
-
-        actualAmountReceived = uint248(afterBalance - beforeBalance);
-        amountInUSD = convertToUsd(_assets, asset, actualAmountReceived);
-    }
-
-    /// @notice Escrows a payment by transferring it from the sender to the contract
-    /// @param _assets The mapping of assets to their payment information.
-    /// @param asset The address of the asset to escrow the payment for.
-    /// @param amount The amount of the asset to escrow.
-    /// @return actualAmountReceived The actual amount received by the contract.
-    function escrowPayment(mapping(address asset => PaymentAsset) storage _assets, address asset, uint248 amount)
-        internal
-        returns (uint248 actualAmountReceived, uint248 amountInUSD)
-    {
-        (actualAmountReceived, amountInUSD) = _pullAndQuote(_assets, asset, address(this), amount);
-    }
-
     /// @notice Transfers asset to recipient and returns actual amount received
     /// @param asset The address of the asset to transfer
     /// @param amount The amount to transfer

--- a/src/libraries/SwapLogic.sol
+++ b/src/libraries/SwapLogic.sol
@@ -151,30 +151,6 @@ library SwapLogic {
         emit MerchantTargetAssetPathSet(merchant, path);
     }
 
-    /// @notice get the path for the source asset which is used to swap the source asset to the USDT token
-    /// @param _swapLogicStorage the storage of the swap logic
-    /// @param sourceAsset the address of the source asset
-    /// @return the path for the source asset
-    function getSourceAssetPath(SwapLogicStorage storage _swapLogicStorage, address sourceAsset)
-        internal
-        view
-        returns (bytes storage)
-    {
-        return _swapLogicStorage.assetSwapPaths.sourceAssetPaths[sourceAsset];
-    }
-
-    /// @notice get the path for the target asset which is used to swap the USDT token to the target asset
-    /// @param _swapLogicStorage the storage of the swap logic
-    /// @param merchant the address of the merchant
-    /// @return the path for the target asset
-    function getMerchantTargetAssetPath(SwapLogicStorage storage _swapLogicStorage, address merchant)
-        internal
-        view
-        returns (bytes storage)
-    {
-        return _swapLogicStorage.assetSwapPaths.merchantTargetAssetPaths[merchant];
-    }
-
     /// @notice get the payout asset address for a merchant by extracting it from their target asset path
     /// @param _swapLogicStorage the storage of the swap logic
     /// @param merchant the address of the merchant

--- a/test/libraries/SwapLogic.t.sol
+++ b/test/libraries/SwapLogic.t.sol
@@ -100,16 +100,6 @@ contract SwapLogicTest is Test {
         assertFalse(SwapLogic.isValidPath(badPath));
     }
 
-    function testSetSourceAssetPath() public {
-        bytes memory path = abi.encodePacked(SOURCE_ASSET, bytes3(0x112233), USDT);
-
-        vm.expectEmit(true, false, false, true);
-        emit SwapLogic.SourceAssetPathSet(SOURCE_ASSET, path);
-        this._setSourceAssetPath(path);
-
-        assertEq(keccak256(SwapLogic.getSourceAssetPath(_swapLogicStorage, SOURCE_ASSET)), keccak256(path));
-    }
-
     function testSetSourceAssetPathInvalidPathReverts() public {
         bytes memory badPath = new bytes(21);
         vm.expectRevert(SwapLogic.InvalidPath.selector);
@@ -131,16 +121,6 @@ contract SwapLogicTest is Test {
         bytes memory zeroPath = abi.encodePacked(ZERO_ADDRESS);
         vm.expectRevert(SwapLogic.PathMustEndWithUSDT.selector);
         this._setSourceAssetPath(zeroPath);
-    }
-
-    function testSetMerchantTargetAssetPath() public {
-        bytes memory path = abi.encodePacked(USDT);
-
-        vm.expectEmit(true, false, false, true);
-        emit SwapLogic.MerchantTargetAssetPathSet(MERCHANT, path);
-        this._setMerchantTargetAssetPath(MERCHANT, path);
-
-        assertEq(keccak256(SwapLogic.getMerchantTargetAssetPath(_swapLogicStorage, MERCHANT)), keccak256(path));
     }
 
     function testSetMerchantTargetAssetPathInvalidPathReverts() public {
@@ -174,18 +154,6 @@ contract SwapLogicTest is Test {
     function testExtractPathOriginAsset() public pure {
         bytes memory path = abi.encodePacked(SOURCE_ASSET, bytes3(0x112233), USDT);
         assertEq(SwapLogic.extractPathOriginAsset(path), SOURCE_ASSET);
-    }
-
-    function testGetSourceAssetPath() public {
-        bytes memory path = abi.encodePacked(SOURCE_ASSET, bytes3(0x112233), USDT);
-        this._setSourceAssetPath(path);
-        assertEq(keccak256(SwapLogic.getSourceAssetPath(_swapLogicStorage, SOURCE_ASSET)), keccak256(path));
-    }
-
-    function testGetMerchantTargetAssetPath() public {
-        bytes memory path = abi.encodePacked(USDT);
-        this._setMerchantTargetAssetPath(MERCHANT, path);
-        assertEq(keccak256(SwapLogic.getMerchantTargetAssetPath(_swapLogicStorage, MERCHANT)), keccak256(path));
     }
 
     function testCalldataExtractPathDestinationAssetAddress() public view {


### PR DESCRIPTION
# Rationale for this change

We should not have unused code.

# What changes are included in this PR?

Deleted the unused, internal functions `escrowPayment`, `getSourceAssetPath`, `getMerchantTargetAssetPath`, and `_pullAndQuote`.

# Are these changes tested?
Some tests are dropped. We should ensure that there is no missing converage.